### PR TITLE
Add text union

### DIFF
--- a/src/canvas/controls/text.cpp
+++ b/src/canvas/controls/text.cpp
@@ -46,7 +46,10 @@ void Text::paint(QPainter *painter) {
   if (target_ == nullptr)
     return;
   QString text = canvas().textInput()->toPlainText() + canvas().textInput()->preeditString();
-  target().setText(text);
+  if (text_cache_ != text) {
+    target().setText(text);
+    text_cache_ = text;
+  }
   target().makeCursorRect(canvas().textInput()->textCursor().position());
   target().setEditing(true);
   QPen pen(document().activeLayer()->color(), 2, Qt::SolidLine);

--- a/src/canvas/controls/text.h
+++ b/src/canvas/controls/text.h
@@ -28,6 +28,7 @@ namespace Controls {
 
   private:
     ShapePtr target_;
+    QString text_cache_;
   };
 
 }

--- a/src/shape/text-shape.cpp
+++ b/src/shape/text-shape.cpp
@@ -47,6 +47,9 @@ void TextShape::makePath() {
     path.addText(QPointF(0, i * line_height_ * font_.pointSizeF()), font_,
                  line);
   };
+  QPainterPath infill{path};
+  infill.setFillRule(Qt::WindingFill);
+  path = path.united(infill);
   setPath(path);
 }
 


### PR DESCRIPTION
* Union the text path instead of subtracting the overlapping part
* Add text cache to prevent `TextShape::setText()` & `TextShape::makePath()` function calls in each `Text::paint()`