### PR TITLE
Bug/Fix bug of layer parameter index go to custom when switch layer

### DIFF
--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -81,6 +81,10 @@ int Layer::power() const {
   return power_;
 }
 
+int Layer::parameterIndex() const {
+  return parameter_index_;
+}
+
 const QString &Layer::name() const {
   return name_;
 }
@@ -154,6 +158,10 @@ void Layer::setStrength(int strength) {
 
 void Layer::setRepeat(int repeat) {
   repeat_ = repeat;
+}
+
+void Layer::setParameterIndex(int parameter_index) {
+  parameter_index_ = parameter_index;
 }
 
 void Layer::setUseDiode(bool is_diode) {

--- a/src/layer.h
+++ b/src/layer.h
@@ -66,6 +66,8 @@ public:
 
   int power() const;
 
+  int parameterIndex() const;
+
   double stepHeight() const;
 
   double targetHeight() const;
@@ -88,6 +90,8 @@ public:
   void setSpeed(int speed);
 
   void setStrength(int strength);
+
+  void setParameterIndex(int parameter_index);
 
   void setType(Type type);
 
@@ -118,6 +122,7 @@ private:
   int repeat_;
   int speed_;
   int power_;
+  int parameter_index_;
 
   /** Main properties **/
   mutable bool cache_valid_;

--- a/src/widgets/panels/layer-params-panel.cpp
+++ b/src/widgets/panels/layer-params-panel.cpp
@@ -70,6 +70,7 @@ void LayerParamsPanel::registerEvents() {
         loadSettings();
       }
       ui->presetComboBox->setCurrentIndex(index_to_recover);
+      if (layer_ != nullptr) layer_->setParameterIndex(index_to_recover);
     } else if (index >= 0 && index < ui->presetComboBox->count() - 2) {
       auto p = PresetSettings::Param::fromJson(ui->presetComboBox->itemData(index).toJsonObject());
       ui->powerSpinBox->blockSignals(true);
@@ -85,8 +86,10 @@ void LayerParamsPanel::registerEvents() {
       layer_->setSpeed(p.speed);
       layer_->setRepeat(p.repeat);
       preset_previous_index_ = index;
+      layer_->setParameterIndex(index);
     } else {
       preset_previous_index_ = index;
+      layer_->setParameterIndex(index);
     }
   });
   connect(ui->movingComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
@@ -136,11 +139,13 @@ void LayerParamsPanel::updateMovingComboBox() {
 }
 
 void LayerParamsPanel::updateLayer(Layer *layer) {
+  int previous_index = layer->parameterIndex();
   layer_ = layer;
   ui->presetParamLabel->setText(tr("Parameter Settings") + "("+ layer->name() + ")");
   ui->powerSpinBox->setValue(layer->power());
   ui->speedSpinBox->setValue(layer->speed());
   ui->repeatSpinBox->setValue(layer->repeat());
+  ui->presetComboBox->setCurrentIndex(previous_index);
   updateMovingComboBox();
 }
 


### PR DESCRIPTION
處理問題
v20220321 圖層的參數名稱再切換圖層後皆會變成custom

於layer中增加parameter index設定 以便update layer(in layer params panel)時更新