### PR TITLE
Bug/delect layer switch to other layer

### DIFF
--- a/src/widgets/components/layer-list-item.cpp
+++ b/src/widgets/components/layer-list-item.cpp
@@ -162,6 +162,8 @@ void LayerListItem::onDeleteLayer() {
       Commands::RemoveSelections(&(layer_->document())),
       Commands::RemoveLayer(layer_)
     );
+    LayerPtr last_layer = canvas_->document().layers().last();
+    canvas_->setActiveLayer(last_layer);
   }
   emit canvas_->layerChanged();
 }


### PR DESCRIPTION
修復bug
v20220605_新增「刪除Layer時，自動切換至任意現有Layer」的功能

當刪除layer後會選擇最新layer設定為active