### PR TITLE
Feature/Set top layer activate after removing current layer

### DIFF
--- a/src/widgets/components/layer-list-item.cpp
+++ b/src/widgets/components/layer-list-item.cpp
@@ -154,16 +154,23 @@ void LayerListItem::onDeleteLayer() {
   if (layer_->document().layers().length() == 1) { // should add one default layer when no layer in the list
     canvas_->addEmptyLayer();
     layer_->document().execute(
-      Commands::RemoveSelections(&(layer_->document())),
+      // Commands::RemoveSelections(&(layer_->document())),
       Commands::RemoveLayer(layer_)
     );
   } else {
+    bool change_layer = false;
+    if(layer_->name() == layer_->document().activeLayer()->name()) {
+      change_layer = true;
+    }
     layer_->document().execute(
-      Commands::RemoveSelections(&(layer_->document())),
+      // Commands::RemoveSelections(&(layer_->document())),
       Commands::RemoveLayer(layer_)
     );
-    LayerPtr last_layer = canvas_->document().layers().last();
-    canvas_->setActiveLayer(last_layer);
+    if(change_layer) {
+      LayerPtr last_layer = canvas_->document().layers().last();
+      canvas_->setActiveLayer(last_layer);
+      canvas_->document().setSelection(nullptr);
+    }
   }
   emit canvas_->layerChanged();
 }


### PR DESCRIPTION
處理問題
v20220617_圈選某一圖層物件時，若刪除其他圖層，圈選物件也會被刪除
v20220617_刪除非目前所在圖層時，還是會切到最上面的圖層，應只有刪除圖層為所選圖層時才需要切到最上面
處理內容
移除刪除select
確認刪除圖層名稱是否與active圖層相同(相同時切換active layer)