### PR TITLE
Bug/fix machine manager add new machine

### DIFF
--- a/src/windows/machine-manager.cpp
+++ b/src/windows/machine-manager.cpp
@@ -58,9 +58,9 @@ void MachineManager::registerEvents() {
   connect(ui->addBtn, &QAbstractButton::clicked, [=]() {
     QListWidgetItem *machine_item = new QListWidgetItem;
     auto machine = MachineSettings::database();
-    machine[0].name = ("New Machine");
+    machine[0].name = tr("New Machine");
     machine_item->setData(Qt::UserRole, machine[0].toJson());
-    machine_item->setText("New Machine");
+    machine_item->setText(machine[0].name);
     ui->machineList->addItem(machine_item);
     ui->removeBtn->setEnabled(true);
   });


### PR DESCRIPTION
處理問題
v20220601_Machine Settings 新增時名稱不能是空白的

處理內容
在新增時同一命名為New Machine
並確認machine list number當數量為一時 disable remove btn