### PR TITLE
Fix bug update font in TextDrawing mode

### DIFF
--- a/src/canvas/canvas.cpp
+++ b/src/canvas/canvas.cpp
@@ -949,6 +949,7 @@ void Canvas::setLayerOrder(QList<LayerPtr> &new_order) {
 }
 
 void Canvas::setFont(const QFont &font) {
+  font_.setFamily(font.family());
   if (!document().selections().isEmpty()) {
     auto cmd = Commands::Joined();
     for (auto &shape: document().selections()) {
@@ -962,10 +963,8 @@ void Canvas::setFont(const QFont &font) {
     document().execute(cmd);
     emit selectionsChanged();
   } else if (mode() == Mode::TextDrawing) {
-    ctrl_text_.target().setFont(font);
+    ctrl_text_.target().setFont(font_);
   }
-
-  font_ = font;
 }
 
 void Canvas::setPointSize(int point_size) {
@@ -983,6 +982,7 @@ void Canvas::setPointSize(int point_size) {
     document().execute(cmd);
     emit selectionsChanged();
   } else if (mode() == Mode::TextDrawing) {
+    target_font.setPointSize(point_size);
     ctrl_text_.target().setFont(target_font);
   }
 
@@ -1004,6 +1004,7 @@ void Canvas::setLetterSpacing(double spacing) {
     document().execute(cmd);
     emit selectionsChanged();
   } else if (mode() == Mode::TextDrawing) {
+    target_font.setLetterSpacing(QFont::SpacingType::AbsoluteSpacing, spacing);
     ctrl_text_.target().setFont(target_font);
   }
 
@@ -1025,6 +1026,7 @@ void Canvas::setBold(bool bold) {
     document().execute(cmd);
     emit selectionsChanged();
   } else if (mode() == Mode::TextDrawing) {
+    target_font.setBold(bold);
     ctrl_text_.target().setFont(target_font);
   }
 
@@ -1046,6 +1048,7 @@ void Canvas::setItalic(bool italic) {
     document().execute(cmd);
     emit selectionsChanged();
   } else if (mode() == Mode::TextDrawing) {
+    target_font.setItalic(italic);
     ctrl_text_.target().setFont(target_font);
   }
 
@@ -1067,6 +1070,7 @@ void Canvas::setUnderline(bool underline) {
     document().execute(cmd);
     emit selectionsChanged();
   } else if (mode() == Mode::TextDrawing) {
+    target_font.setUnderline(underline);
     ctrl_text_.target().setFont(target_font);
   }
 


### PR DESCRIPTION
處理問題
當在文字編輯模式下 修改字型大小/粗體/斜體/底線/文字間隔無效
處理內容
在TextDrawing模式下 將修改項目更新並紀錄於canvas中