### PR TITLE
Fix bug text control crash when edit without text & keep line height …

### DIFF
--- a/src/canvas/canvas.cpp
+++ b/src/canvas/canvas.cpp
@@ -37,6 +37,7 @@ Canvas::Canvas(QQuickItem *parent)
        widget_(nullptr),
        fps(0),
        font_(QFont(FONT_TYPE, FONT_SIZE, QFont::Bold)),
+       line_height_(LINE_HEIGHT),
        timer(new QTimer(this)),
        mem_thread_(new QThread(this)) {
 
@@ -971,8 +972,10 @@ void Canvas::setFont(const QFont &font) {
     }
     document().execute(cmd);
     emit selectionsChanged();
-  } else if (mode() == Mode::TextDrawing) {
-    ctrl_text_.target().setFont(font_);
+  } else {
+    if(!ctrl_text_.isEmpty()) {
+      ctrl_text_.target().setFont(font_);
+    }
   }
 }
 
@@ -990,11 +993,12 @@ void Canvas::setPointSize(int point_size) {
     }
     document().execute(cmd);
     emit selectionsChanged();
-  } else if (mode() == Mode::TextDrawing) {
+  } else {
     target_font.setPointSize(point_size);
-    ctrl_text_.target().setFont(target_font);
+    if(!ctrl_text_.isEmpty()) {
+      ctrl_text_.target().setFont(target_font);
+    }
   }
-
   font_ = target_font;
 }
 
@@ -1012,11 +1016,12 @@ void Canvas::setLetterSpacing(double spacing) {
     }
     document().execute(cmd);
     emit selectionsChanged();
-  } else if (mode() == Mode::TextDrawing) {
+  } else {
     target_font.setLetterSpacing(QFont::SpacingType::AbsoluteSpacing, spacing);
-    ctrl_text_.target().setFont(target_font);
+    if(!ctrl_text_.isEmpty()) {
+      ctrl_text_.target().setFont(target_font);
+    }
   }
-
   font_ = target_font;
 }
 
@@ -1034,11 +1039,12 @@ void Canvas::setBold(bool bold) {
     }
     document().execute(cmd);
     emit selectionsChanged();
-  } else if (mode() == Mode::TextDrawing) {
+  } else {
     target_font.setBold(bold);
-    ctrl_text_.target().setFont(target_font);
+    if(!ctrl_text_.isEmpty()) {
+      ctrl_text_.target().setFont(target_font);
+    }
   }
-
   font_ = target_font;
 }
 
@@ -1056,11 +1062,12 @@ void Canvas::setItalic(bool italic) {
     }
     document().execute(cmd);
     emit selectionsChanged();
-  } else if (mode() == Mode::TextDrawing) {
+  } else {
     target_font.setItalic(italic);
-    ctrl_text_.target().setFont(target_font);
+    if(!ctrl_text_.isEmpty()) {
+      ctrl_text_.target().setFont(target_font);
+    }
   }
-
   font_ = target_font;
 }
 
@@ -1078,15 +1085,17 @@ void Canvas::setUnderline(bool underline) {
     }
     document().execute(cmd);
     emit selectionsChanged();
-  } else if (mode() == Mode::TextDrawing) {
+  } else {
     target_font.setUnderline(underline);
-    ctrl_text_.target().setFont(target_font);
+    if(!ctrl_text_.isEmpty()) {
+      ctrl_text_.target().setFont(target_font);
+    }
   }
-
   font_ = target_font;
 }
 
 void Canvas::setLineHeight(float line_height) {
+  line_height_ = line_height;
   if (!document().selections().isEmpty()) {
     auto cmd = Commands::Joined();
     for (auto &shape: document().selections()) {
@@ -1096,8 +1105,10 @@ void Canvas::setLineHeight(float line_height) {
     }
     document().execute(cmd);
     emit selectionsChanged();
-  } else if (mode() == Mode::TextDrawing) {
-    ctrl_text_.target().setLineHeight(line_height);
+  } else {
+    if(!ctrl_text_.isEmpty()) {
+      ctrl_text_.target().setLineHeight(line_height);
+    }
   }
 }
 
@@ -1153,6 +1164,8 @@ bool Canvas::isVolatile() const {
 }
 
 const QFont &Canvas::font() const { return font_; }
+
+double Canvas::lineHeight() const { return line_height_;}
 
 void Canvas::editHFlip() {
   transformControl().applyScale(transformControl().boundingRect().center(), -1, 1, false);

--- a/src/canvas/canvas.h
+++ b/src/canvas/canvas.h
@@ -84,6 +84,8 @@ public:
 
   const QFont &font() const;
 
+  double lineHeight() const;
+
   CanvasTextEdit *textInput() const;
 
   // Graphics should be drawn in lower quality is this return true
@@ -210,6 +212,7 @@ private:
   std::unique_ptr<Document> doc_;
   Mode mode_;
   QFont font_;
+  double line_height_;
   Clipboard clipboard_;
   Parser::SVGPPParser svgpp_parser_;
 

--- a/src/canvas/controls/text.cpp
+++ b/src/canvas/controls/text.cpp
@@ -22,7 +22,7 @@ bool Text::mouseReleaseEvent(QMouseEvent *e) {
   canvas().textInput()->setFocus();
   if (target_ == nullptr) {
     // Create a virtual target
-    ShapePtr new_shape = std::make_shared<TextShape>("", canvas().font());
+    ShapePtr new_shape = std::make_shared<TextShape>("", canvas().font(), canvas().lineHeight());
     setTarget(new_shape);
     target().setTransform(QTransform().translate(canvas_coord.x(), canvas_coord.y()));
   }
@@ -85,5 +85,14 @@ void Text::setTarget(ShapePtr &new_target) {
   target_ = new_target;
   if (target_ != nullptr) {
     canvas().textInput()->setPlainText(target().text());
+  }
+}
+
+bool Text::isEmpty() {
+  if(target_ != nullptr) {
+    return false;
+  }
+  else {
+    return true;
   }
 }

--- a/src/canvas/controls/text.h
+++ b/src/canvas/controls/text.h
@@ -26,6 +26,8 @@ namespace Controls {
 
     void setTarget(ShapePtr &target);
 
+    bool isEmpty();
+
   private:
     ShapePtr target_;
     QString text_cache_;

--- a/src/shape/text-shape.cpp
+++ b/src/shape/text-shape.cpp
@@ -5,8 +5,8 @@
 
 TextShape::TextShape() noexcept: PathShape() { line_height_ = LINE_HEIGHT; }
 
-TextShape::TextShape(QString text, QFont font) : PathShape() {
-  line_height_ = LINE_HEIGHT;
+TextShape::TextShape(QString text, QFont font, double line_height) : PathShape() {
+  line_height_ = line_height;
   lines_ = text.split("\n");
   font_ = font;
   makePath();

--- a/src/shape/text-shape.h
+++ b/src/shape/text-shape.h
@@ -7,7 +7,7 @@ class TextShape : public PathShape {
 public:
   TextShape() noexcept;
 
-  TextShape(QString text, QFont font);
+  TextShape(QString text, QFont font, double line_height);
 
   void paint(QPainter *painter) const override;
 


### PR DESCRIPTION
處理問題
v20220706_切換到Text 時若未點擊cavans ，直接設定文字參數就會閃退
v20220706_文字參數在select (箭頭)型態時無法被記住
v20220304 文字更改行高後，再次新增文字未更動
處理內容
於canvas內紀錄行高
text控制新增api來確認是否文字內容為空
除了編輯模式中更新canvas紀錄font