### PR TITLE
Fix unexpected trigger of soft limit alarm

### DIFF
--- a/src/toolpath_exporter/generators/gcode-generator.h
+++ b/src/toolpath_exporter/generators/gcode-generator.h
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <toolpath_exporter/generators/base-generator.h>
 #include <settings/machine-settings.h>
+#include <cmath>
 
 /*
 Basic GCode Generator for Grbl like machines.
@@ -63,58 +64,63 @@ public:
     }
 
     // 2 Limit x,y position inside the work area
-    if (x > machine_width_) {
-      x = machine_width_;
-    } else if (x < 0) {
-      x = 0;
+    //   NOTE: Also need to consider the precision error of floating point number
+    //         so we add an epsilon here
+    if (x > machine_width_ - epsilon_) {
+      x = machine_width_ - epsilon_;
+    } else if (x < epsilon_) {
+      x = epsilon_;
     }
-    if (y > machine_height_) {
-      y = machine_height_;
-    } else if (y < 0) {
-      y = 0;
+    if (y > machine_height_ - epsilon_) {
+      y = machine_height_ - epsilon_;
+    } else if (y < epsilon_) {
+      y = epsilon_;
     }
 
     // 3. Separate relative mode & absolute mode
     if (distance_modal_ == GCodeDistanceModal::kG91) { // G91: relative distance
-      if (x != x_ || y != y_) {
+      if (std::fabs(x - x_) >= epsilon_ || std::fabs(y - y_) >= epsilon_) {
         if ( motion_modal_ != GCodeMotionModal::kG01) {
           str_stream_ << "G1";
           motion_modal_ = GCodeMotionModal::kG01;
         }
       }
-      if (x != x_) {
-        str_stream_ << "X" << round((x - x_) * 1000) / 1000;
-        x_ = x;
+      if (std::fabs(x - x_) >= epsilon_) {
+        float dist_x = round((x - x_) * 1000) / 1000;
+        str_stream_ << "X" << dist_x;
+        x_ = x_ + dist_x;
       }
-      if (y != y_) {
-        str_stream_ << "Y" << round((y - y_) * 1000) / 1000;
-        y_ = y;
+      if (std::fabs(y - y_) >= epsilon_) {
+        float dist_y = std::round((y - y_) * 1000) / 1000;
+        str_stream_ << "Y" << dist_y;
+        y_ = y_ + dist_y;
       }
     } else { // G90: absolute distance
       // Coordinate transform for different origin type
-      if (x_ == x && y_ == y && speed_ == speed && power_ == power)
+      if (std::fabs(x - x_) < epsilon_ && std::fabs(y - y_) < epsilon_ 
+          && std::fabs(speed_ - speed) < epsilon_ && std::fabs(power_ - power) < epsilon_)
         return;
 
       if ( motion_modal_ != GCodeMotionModal::kG01) {
         str_stream_ << "G1";
         motion_modal_ = GCodeMotionModal::kG01;
       }
-      if (x_ != x) {
-        str_stream_ << "X" << round(x * 1000) / 1000;
+      if (std::fabs(x - x_) >= epsilon_) {
+        str_stream_ << "X" << std::round(x * 1000) / 1000;
         x_ = x;
       }
-      if (y_ != y) {
-        str_stream_ << "Y" << round(y * 1000) / 1000;
+      if (std::fabs(y - y_) >= epsilon_) {
+        str_stream_ << "Y" << std::round(y * 1000) / 1000;
         y_ = y;
       }
     }
 
-    if (speed_ != speed) {
+    if (std::fabs(speed_ - speed) >= epsilon_) {
       str_stream_ << "F" << speed * 60; // mm/s to mm/min
       speed_ = speed;
     }
 
-    if (power_ != power) {
+    if (std::fabs(power_ - power) >= epsilon_) {
       str_stream_ << "S" << power * 10; // mm/s to mm/min
       power_ = power;
     }
@@ -176,4 +182,5 @@ private:
   GCodeDistanceModal distance_modal_ = GCodeDistanceModal::kG90;
   MCodeSpindleModal spindle_modal_ = MCodeSpindleModal::kM05;
   MachineSettings::MachineSet::OriginType machine_origin_;
+  float epsilon_ = 0.001;
 };

--- a/src/toolpath_exporter/toolpath-exporter.cpp
+++ b/src/toolpath_exporter/toolpath-exporter.cpp
@@ -405,6 +405,7 @@ std::tuple<std::vector<std::bitset<32>>, uint32_t, uint32_t> ToolpathExporter::a
  *
  * @param layer_image the (scaled) bitmap of entire layer
  * @param bbox bounding box of dirty area
+ *             NOTE: the bbox has already been scaled by dpmm
  * @param diection_mode
  * @return
  */
@@ -419,11 +420,13 @@ bool ToolpathExporter::rasterBitmap(const QImage &layer_image,
 
   // Prepare raster line paths
   QList<QLine> raster_lines;
+  // NOTE: Use bbox.left() + bbox.width() instead of bbox.right() 
+  //       since the latter is the left position of the last pixel instead of the right boundary of the work area
   for (int y = bbox.top(); y <= bbox.bottom(); y += 1) {
     raster_lines.push_back(QLine{bbox.left(), y,
-                                 bbox.right(), y});
+                                 bbox.left() + bbox.width(), y});
   }
-  qInfo() << "bbox: " << bbox;
+  qInfo() << "bbox: " << bbox << bbox.left() << ", " << bbox.right();;
   qInfo() << "# of raster line: " << raster_lines.size();
 
   // 2-2. iterate
@@ -543,6 +546,7 @@ bool ToolpathExporter::rasterLine(const QLineF& path, const std::vector<std::bit
  * @brief Export
  * @param layer_image  (scaled) image of an entire layer on canvas
  * @param bbox         the (scaled) bounding box for the raster motion (shouldn't be larger than layer_image)
+ *                     NOTE: the bbox has already been scaled by dpmm
  * @return
  */
 bool ToolpathExporter::rasterBitmapHighSpeed(const QImage &layer_image,
@@ -565,9 +569,11 @@ bool ToolpathExporter::rasterBitmapHighSpeed(const QImage &layer_image,
 
   // 2-1. Prepare raster line paths
   QList<QLine> raster_lines;
+  // NOTE: Use bbox.left() + bbox.width() instead of bbox.right() 
+  //       since the latter is the left position of the last pixel instead of the right boundary of the work area
   for (int y = bbox.top(); y <= bbox.bottom(); y += 1) {
     raster_lines.push_back(QLine{bbox.left(), y,
-                                  bbox.right(), y});
+                                  bbox.left() + bbox.width(), y});
   }
   qInfo() << "bbox: " << bbox;
   qInfo() << "# of raster line: " << raster_lines.size();

--- a/src/toolpath_exporter/toolpath-exporter.cpp
+++ b/src/toolpath_exporter/toolpath-exporter.cpp
@@ -426,7 +426,7 @@ bool ToolpathExporter::rasterBitmap(const QImage &layer_image,
     raster_lines.push_back(QLine{bbox.left(), y,
                                  bbox.left() + bbox.width(), y});
   }
-  qInfo() << "bbox: " << bbox << bbox.left() << ", " << bbox.right();;
+  qInfo() << "bbox: " << bbox;
   qInfo() << "# of raster line: " << raster_lines.size();
 
   // 2-2. iterate


### PR DESCRIPTION
# Description

Solve the problem of soft limit alarm caused by precision error of floating point number.
Reserve an epsilon distance within the boundary.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

