### PR TITLE
Add check line when select inside

### DIFF
--- a/src/canvas/controls/select.cpp
+++ b/src/canvas/controls/select.cpp
@@ -38,7 +38,9 @@ bool Select::mouseReleaseEvent(QMouseEvent *e) {
       for (auto &shape : layer->children()) {
         if (shape->hitTest(selection_box_)) {
           if(check_inside_) {
-            if(selection_box_.contains(shape->boundingRect())) selected << shape;
+            if(selection_box_.contains(shape->boundingRect()) ||
+              (selection_box_.contains(shape->boundingRect().topLeft()) && 
+                selection_box_.contains(shape->boundingRect().bottomRight()))) selected << shape;
           } else {
             selected << shape;
           }


### PR DESCRIPTION
# Description

Add check line when select inside.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Add line in canvas and select by multi-select(from left to right)
