### PR TITLE
Add rotary info to QSetting

### DIFF
--- a/src/widgets/panels/doc-panel.cpp
+++ b/src/widgets/panels/doc-panel.cpp
@@ -75,6 +75,21 @@ void DocPanel::loadSettings() {
     ui->machineComboBox->addItem(mach.icon(), " " + mach.name, mach.toJson());
     ui->machineComboBox->blockSignals(false);
   }
+  //these should add in machine
+  QVariant travel_speed = settings.value("travelSpeed", 0);
+  if(travel_speed.toDouble() > 0) {
+    ui->speedSpinBox->setValue(travel_speed.toDouble());
+  } else {
+    ui->speedSpinBox->setValue(100);
+    settings.setValue("travelSpeed", 100);
+  }
+  QVariant rotary_speed = settings.value("rotary/travelSpeed", 0);
+  if(rotary_speed.toDouble() > 0) {
+    ui->rotarySpinBox->setValue(rotary_speed.toDouble());
+  } else {
+    ui->rotarySpinBox->setValue(5);
+    settings.setValue("rotary/travelSpeed", 5);
+  }
   // select the item in combobox with matching current_machine name
   // NOTE: This works only when there is no duplicate name in machines_
   ui->machineComboBox->setCurrentText(current_machine);
@@ -163,9 +178,13 @@ void DocPanel::registerEvents() {
     Q_EMIT rotaryModeChange(state);
   });
   connect(ui->speedSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), [=](double value) {
+    QSettings settings;
+    settings.setValue("travelSpeed", value);
     Q_EMIT updateSpeed();
   });
   connect(ui->rotarySpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), [=](double value) {
+    QSettings settings;
+    settings.setValue("rotary/travelSpeed", value);
     Q_EMIT updateSpeed();
   });
 }

--- a/src/widgets/panels/doc-panel.ui
+++ b/src/widgets/panels/doc-panel.ui
@@ -183,6 +183,9 @@
            <property name="decimals">
             <number>1</number>
            </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
            </property>
@@ -212,6 +215,9 @@
            </property>
            <property name="decimals">
             <number>1</number>
+           </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -99,6 +99,7 @@ void MainWindow::loadSettings() {
   current_filename_ = tr("Untitled");
   updateTravelSpeed();
   rotary_setup_->setFramingPower(jogging_panel_->getFramingPower());
+  rotary_setup_->setDefaultCircumference(machine_info.height);
   canvas_->setCurrentPosition(jogging_panel_->getShowCurrent());
   canvas_->setUserOrigin(jogging_panel_->getShowUserOrigin());
 #ifdef ENABLE_SENTRY

--- a/src/windows/rotary_setup.cpp
+++ b/src/windows/rotary_setup.cpp
@@ -2,6 +2,7 @@
 #include "ui_rotary_setup.h"
 #define _USE_MATH_DEFINES
 #include <math.h>
+#include <QSettings>
 #include <windows/osxwindow.h>
 
 #include <QDebug>
@@ -68,6 +69,9 @@ RotarySetup::RotarySetup(QWidget *parent) :
         type_index_ = ui->typeList->currentRow();
         mm_per_rotation_ = ui->mmPerRotationSpinBox->value();
         roller_diameter_ = ui->rollerDiameterSpinBox->value();
+
+        QSettings settings;
+        settings.setValue("rotary/circumference", circumference_);
 
         Q_EMIT mirrorModeChanged(is_mirror_mode_);
         Q_EMIT rotaryAxisChanged(rotary_axis_);
@@ -150,6 +154,22 @@ void RotarySetup::setControlEnable(bool control_enable)
     else {
         ui->testBtn->setEnabled(false);
     }
+}
+
+void RotarySetup::setDefaultCircumference(double default_value)
+{
+    //if the rotary/circumference is not update
+    QSettings settings;
+    QVariant circumference_data = settings.value("rotary/circumference", 0);
+    if(circumference_data.toDouble() > 0) {
+        ui->CircumSpinBox->setValue(circumference_data.toDouble());
+        circumference_ = circumference_data.toDouble();
+    } else {
+        ui->CircumSpinBox->setValue(default_value);
+        settings.setValue("rotary/circumference", default_value);
+        circumference_ = default_value;
+    }
+    resetUI();
 }
 
 /**

--- a/src/windows/rotary_setup.h
+++ b/src/windows/rotary_setup.h
@@ -38,6 +38,8 @@ public:
 
     void setControlEnable(bool control_enable);
 
+    void setDefaultCircumference(double default_value);
+
 private:
     Ui::RotarySetup *ui;
     void testRotary();

--- a/src/windows/rotary_setup.ui
+++ b/src/windows/rotary_setup.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>463</width>
+    <width>473</width>
     <height>483</height>
    </rect>
   </property>


### PR DESCRIPTION
# Description

Add rotary info to QSetting to remember user setting.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Update travel speed and close to see the setting is rewrite or not.
