### PR TITLE
Add machine width protect when read jason and setting by machine manager

### DIFF
--- a/src/document.cpp
+++ b/src/document.cpp
@@ -149,8 +149,13 @@ qreal Document::width() const { return width_; }
 qreal Document::height() const { return height_; }
 
 void Document::setWidth(qreal width) {
-  width_ = width;
-  settings_.width = width;
+  if(width <= 0) {
+    width_ = 5;
+    settings_.width = 5;
+  } else {
+    width_ = width;
+    settings_.width = width;
+  }
 }
 
 void Document::setHeight(qreal height) {

--- a/src/settings/machine-settings.cpp
+++ b/src/settings/machine-settings.cpp
@@ -92,6 +92,7 @@ MachineSet MachineSet::fromJson(const QJsonObject &obj) {
   m.icon_url = obj["icon"].toString();
 
   m.width = obj["width"].toInt();
+  if(m.width <= 0) m.width = 5;
   m.height = obj["height"].toInt();
 
   m.origin = (MachineSet::OriginType) obj["origin"].toInt();

--- a/src/settings/machine-settings.h
+++ b/src/settings/machine-settings.h
@@ -54,7 +54,7 @@ public:
 
     BoardType board_type;
     OriginType origin;
-    int width = 0;
+    int width = 5;
     int height = 0;
     bool home_on_start;
     QPointF red_pointer_offset;

--- a/src/windows/machine-manager.ui
+++ b/src/windows/machine-manager.ui
@@ -214,6 +214,9 @@
             <property name="suffix">
              <string> mm</string>
             </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
             <property name="maximum">
              <number>3000</number>
             </property>
@@ -238,8 +241,14 @@
             <property name="suffix">
              <string> mm</string>
             </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
             <property name="maximum">
              <number>3000</number>
+            </property>
+            <property name="value">
+             <number>0</number>
             </property>
            </widget>
           </item>

--- a/src/windows/qml/OtherMachinePage.qml
+++ b/src/windows/qml/OtherMachinePage.qml
@@ -93,7 +93,7 @@ Item {
                     id: spinBoxHeight
                     value: 100
                     Layout.preferredWidth: 150
-                    from: 5
+                    from: 0
                     to: 10000
                     enabled: true
                     editable: true


### PR DESCRIPTION
# Description

Add machine width protect when read jason and setting by machine manager.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To set machine width 0
