### PR TITLE
Bug/version update without speed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
-project(Swiftray VERSION 1.2.0)
+project(Swiftray VERSION 1.2.1)
 message("System Name: ${CMAKE_SYSTEM_NAME}")
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 2)
-set(VERSION_BUILD 0)
+set(VERSION_BUILD 1)
 set(VERSION_BETA  0) #x (e.g. 0,1,2,...)
 set(VERSION_SUFFIX "") # e.g. empty("") or "-beta.x"
 #set(PROJECT_VERSION_STR "1.1.2") # e.g. 1.x.x or 1.x.x-beta.x

--- a/src/settings/machine-settings.cpp
+++ b/src/settings/machine-settings.cpp
@@ -107,12 +107,20 @@ MachineParam MachineParam::fromJson(const QJsonObject &obj) {
        obj["redPointerOffsetY"].toInt()
   );
   if(!obj["travel_speed"].isNull()) m.travel_speed = obj["travel_speed"].toDouble();
+  else {
+    m.travel_speed = 100;
+  }
   if(!obj["rotary_axis"].isNull()) m.rotary_axis = *obj["rotary_axis"].toString().toStdString().c_str();
+  else {
+    m.rotary_axis = 'Y';
+  }
   if(!obj["is_high_speed_mode"].isNull()) m.is_high_speed_mode = obj["is_high_speed_mode"].toBool();
   else {
     std::size_t found = m.name.toStdString().find("Lazervida");
     if(found!=std::string::npos) {
       m.is_high_speed_mode = true;
+    } else {
+      m.is_high_speed_mode = false;
     }
   }
   return m;

--- a/swiftray.pro
+++ b/swiftray.pro
@@ -16,7 +16,7 @@ TARGET = Swiftray
 #Application version
 VERSION_MAJOR = 1
 VERSION_MINOR = 2
-VERSION_BUILD = 0
+VERSION_BUILD = 1
 VERSION_SUFFIX = "" # empty string or "-beta.X"
 #DEFINES += "VERSION_MAJOR=$$VERSION_MAJOR"\
 #       "VERSION_MINOR=$$VERSION_MINOR"\


### PR DESCRIPTION
# Description

version update without speed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

window swiftray version 1.1.3 to set machine and update swiftray to this version to check the travel speed
