### PR TITLE
Update fcode converter

### DIFF
--- a/src/parser/my_qsvg_handler_qt6.cpp
+++ b/src/parser/my_qsvg_handler_qt6.cpp
@@ -56,6 +56,7 @@ Q_LOGGING_CATEGORY(lcSvgHandler, "qt.svg")
 QImage g_image;
 QColor g_color = Qt::black;
 double g_scale = 1;
+QRectF g_bbox;
 bool g_gradient = true;
 int g_threshold = 128;
 bool g_pwm = false;
@@ -2939,6 +2940,7 @@ static QSvgNode *createImageNode(QSvgNode *parent,
     const QStringView width  = attributes.value(QLatin1String("width"));
     const QStringView height = attributes.value(QLatin1String("height"));
     QString filename = attributes.value(QLatin1String("xlink:href")).toString();
+    g_bbox.setRect(x.toFloat(), y.toFloat(), width.toFloat(), height.toFloat());
     g_gradient = attributes.value("data-shading").toString() == "true";
     g_threshold = attributes.value("data-threshold").toInt();
     g_pwm = attributes.value("data-pwm").toInt() == 1;
@@ -5084,7 +5086,7 @@ bool MyQSvgHandler::startElement(const QString &localName,
 
     if (node) {
 #ifdef MYSVG
-        MySVG::processMySVGNode(node, data_list_, this->read_type_, layer_config_map_, g_scale, g_color, g_image, g_gradient, g_threshold, g_pwm);
+        MySVG::processMySVGNode(node, data_list_, this->read_type_, layer_config_map_, g_scale, g_color, g_image, g_bbox, g_gradient, g_threshold, g_pwm);
 #endif
         m_nodes.push(node);
         m_skipNodes.push(Graphics);

--- a/src/parser/my_qsvg_handler_qt6.h
+++ b/src/parser/my_qsvg_handler_qt6.h
@@ -105,6 +105,7 @@ public:
 
     void setAnimPeriod(int start, int end);
     int animationDuration() const;
+    int nextLayerIndex();
 
 #ifndef QT_NO_CSSPARSER
     void parseCSStoXMLAttrs(const QString &css, QList<QSvgCssAttribute> *attributes);
@@ -180,6 +181,7 @@ private:
     QList<MySVG::Node> data_list_;
     MySVG::ReadType read_type_;
     QList<LayerPtr> svg_layers_;
+    int svg_layer_index_;
     QMap<QString, MySVG::BeamLayerConfig> layer_config_map_;
 #endif
 };

--- a/src/parser/mysvg/mysvg-functions.h
+++ b/src/parser/mysvg/mysvg-functions.h
@@ -138,7 +138,7 @@ namespace MySVG {
 
     void processMySVGNode(QSvgNode *node, QList<Node> &nodes,
                           MySVG::ReadType read_type, QMap<QString, MySVG::BeamLayerConfig> &layer_config_map_,
-                          double g_scale, QColor &g_color, QImage &g_image, bool g_gradient = true, int g_threshold = 128, bool g_pwm = false) {
+                          double g_scale, QColor &g_color, QImage &g_image, QRectF g_bbox = QRectF(),  bool g_gradient = true, int g_threshold = 128, bool g_pwm = false) {
         qInfo() << "Processing node" << node->nodeId() << "type" << node->type() << "color" << g_color;
         QTransform trans = getNodeTransform(node);
         double scale = 1;
@@ -168,11 +168,10 @@ namespace MySVG {
             n.visible = getNodeVisible(node);
             nodes.push_back(n);
         } else if(node->type() == QSVG_IMAGE) {
-            QRectF bbox = node->transformedBounds();
             QSize img_size = g_image.size();
-            QTransform tmp_scale = QTransform().translate(bbox.x(), bbox.y())
-                                               .scale(g_scale * scale * bbox.width() / img_size.width(),
-                                                      g_scale * scale * bbox.height() / img_size.height());
+            QTransform tmp_scale = QTransform().translate(g_bbox.x(), g_bbox.y())
+                                               .scale(g_scale * scale * g_bbox.width() / img_size.width(),
+                                                      g_scale * scale * g_bbox.height() / img_size.height());
 
             Node n;
             n.type = QSVG_IMAGE;
@@ -184,7 +183,7 @@ namespace MySVG {
                 tmp_node = tmp_node->parent();
             }
             n.layer_name = (read_type == ReadType::BVG) ? getBVGLayerName(node, layer_config_map_) : getNodeLayerName(node);
-            n.trans = trans * tmp_scale;
+            n.trans = tmp_scale * trans;
             n.color = g_color;
             n.visible = getNodeVisible(node);
             n.gradient = g_gradient;

--- a/src/parser/mysvg/mysvg-types.h
+++ b/src/parser/mysvg/mysvg-types.h
@@ -28,6 +28,7 @@ namespace MySVG {
     };
 
     struct BeamLayerConfig {
+        int order_index;
         bool visible;
         float speed;
         float power;

--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -201,6 +201,7 @@ bool SwiftrayServer::handleParserAction(QWebSocket* socket, const QString& id, c
       result["fcode"] = QString(QByteArray::fromStdString(exporter.toString()).toBase64());
       result["fileName"] = "swiftray-conversion";
       result["timeCost"] = exporter.getTimeCost();
+      result["metadata"] = exporter.getMetadata();
     } else {
     bool enable_high_speed = type == "fcode" && (m_machine == NULL || this->m_machine->getMachineParam().is_high_speed_mode);
     // Generate GCode

--- a/src/toolpath_exporter/generators/fcode-generator.h
+++ b/src/toolpath_exporter/generators/fcode-generator.h
@@ -330,6 +330,7 @@ class FCodeGeneratorV1 : public FCodeGenerator {
   double time_cost;
   float max_x, max_y, max_z, max_r;
   const QString* thumbnail;
+  bool start_with_home;
 
   void write(const char* buf, size_t size, unsigned long* crc32_ptr) override {
     stream->write(buf, size);
@@ -455,11 +456,12 @@ class FCodeGeneratorV1 : public FCodeGenerator {
     write_metadata_("MAX_R", QString::number(max_r + 0.2, 'f', 2), &crc_val);
     write_metadata_("CREATED_AT", created_at.toString(time_format), &crc_val);
     write_metadata_("SOFTWARE", sw_version, &crc_val);
+    write_metadata_("START_WITH_HOME", start_with_home ? "1" : "0", &crc_val);
     return crc_val;
   }
 
  public:
-  FCodeGeneratorV1(const QString* canvas_thumbnail) : thumbnail(canvas_thumbnail) {
+  FCodeGeneratorV1(const QString* canvas_thumbnail, bool with_custom_origin) : thumbnail(canvas_thumbnail) {
     qInfo() << "FCodeGenerator V1 init";
     stream = new std::stringstream();
     created_at = QDateTime::currentDateTime();
@@ -469,6 +471,7 @@ class FCodeGeneratorV1 : public FCodeGenerator {
     traveled = time_cost = 0;
     max_x = max_y = max_z = max_r = 0;
     script_crc32 = 0;
+    start_with_home = !with_custom_origin;
 
     write_magic_number(1);
     script_offset = stream->tellp();
@@ -546,6 +549,7 @@ class FCodeGeneratorV2 : public FCodeGenerator {
   double time_cost;
   float max_x, max_y, max_z;
   const QString* thumbnail;
+  bool start_with_home;
 
   // Ignore crc32_ptr; will be calculated when copying to fc_stream
   void write(const char* buf, size_t size, unsigned long* crc32_ptr) override {
@@ -571,7 +575,7 @@ class FCodeGeneratorV2 : public FCodeGenerator {
   }
 
  public:
-  FCodeGeneratorV2(const QString* canvas_thumbnail, int magic_number)
+  FCodeGeneratorV2(const QString* canvas_thumbnail, int magic_number, bool with_custom_origin)
       : thumbnail(canvas_thumbnail) {
     qInfo() << "FCodeGenerator V2 init";
     created_at = QDateTime::currentDateTime();
@@ -583,6 +587,7 @@ class FCodeGeneratorV2 : public FCodeGenerator {
     traveled = time_cost = 0;
     max_x = max_y = max_z = 0;
     script_crc32 = 0;
+    start_with_home = !with_custom_origin;
 
     start = fc_stream->tellp();
     write_magic_number(magic_number);
@@ -750,6 +755,7 @@ class FCodeGeneratorV2 : public FCodeGenerator {
     write_metadata_("version", "2", &crc_val);
     write_metadata_("CREATED_AT", created_at.toString(time_format), &crc_val);
     write_metadata_("SOFTWARE", sw_version, &crc_val);
+    write_metadata_("START_WITH_HOME", start_with_home ? "1" : "0", &crc_val);
     write_metadata_("max_z", QString::number(max_z + 0.2, 'f', 2), &crc_val, false);
     write_metadata_("max_y", QString::number(max_y + 0.2, 'f', 2), &crc_val, false);
     write_metadata_("max_x", QString::number(max_x + 0.2, 'f', 2), &crc_val, false);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -778,6 +778,9 @@ void ToolpathExporterFcode::convertPath(const PathShape* path) {
   } else {
     polygons_mutex_.lock();
     layer_polygons_.append(transformed_path.toSubpathPolygons());
+    if (is_v2_) {
+      preview_painter_->drawPath(transformed_path * getPreviewTransform());
+    }
     polygons_mutex_.unlock();
   }
 }
@@ -1689,7 +1692,7 @@ void ToolpathExporterFcode::writePreviewImage() {
   QByteArray byteArray;
   QBuffer buffer(&byteArray);
   output_image.save(&buffer, "PNG");
-  gen_->write_string("PREVIEW\n", 8);
+  gen_->write_string("PREV", 4);
   gen_->write_string(byteArray.data(), byteArray.size(), true);
 }
 

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -1130,11 +1130,13 @@ bool ToolpathExporterFcode::rasterLine(const uchar* data_ptr,
   }
 
   if (current_x >= 0) {
-    qreal real_x = getXValInMM(reverse_raster_dir ? current_x + 1 : current_x,
-                               reverse_raster_dir, true);
+    qreal real_x = px2mm(reverse_raster_dir ? current_x + 1 : current_x, true);
     if (has_unfinished_move) {
-      moveto(std::nanf(""), real_x);
+      qreal move_x = qMax(real_x, float(0)) - module_offset_.x();
+      moveto(std::nanf(""), move_x);
     }
+    if (!reverse_raster_dir)
+      real_x += backlash_;
     qreal laser_padding = 25;
     if (config_.enable_mock_fast_gradient) {
       laser_padding = padding_mm_;

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -261,7 +261,7 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
           gen_->set_toolhead_pwm(0);
         }
         moveto(std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""), 0);
-        if (has_focus_adjust_ && repeat > 1) {
+        if (has_focus_adjust_ && focus_step_ > 0 && repeat > 1) {
           float total_step = focus_step_ * (repeat - 1);
           gen_->sync_motion_type2(184, 128, -total_step);
         }

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -561,10 +561,10 @@ void ToolpathExporterFcode::updateClip() {
     layer_clip[i] = qMax((config_.workarea_clip[i]), float(module_clip[i]));
   }
 
-  int clip_top = mm2px(layer_clip[0]);
-  int clip_right = mm2px(work_area_mm_.width() - layer_clip[1], true) - 1;
-  int clip_bottom = mm2px(work_area_mm_.height() - layer_clip[2]) - 1;
-  int clip_left = mm2px(layer_clip[3], true);
+  float clip_top = mm2px(layer_clip[0]);
+  float clip_right = mm2px(work_area_mm_.width() - layer_clip[1], true) - 1;
+  float clip_bottom = mm2px(work_area_mm_.height() - layer_clip[2]) - 1;
+  float clip_left = mm2px(layer_clip[3], true);
   clip_area_ = QRect(QPoint(clip_left, clip_top), QPoint(clip_right, clip_bottom));
   border_lines_[0] = QLineF(clip_left, clip_top, clip_right, clip_top);
   border_lines_[1] = QLineF(clip_right, clip_top, clip_right, clip_bottom);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -424,7 +424,7 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
 void ToolpathExporterFcode::updateLayerParam() {
   layer_module_ = with_module_ ? current_layer_->module() : 15; // 15 = UNIVERSAL_LASER
   is_printing_layer_ = layer_module_ == 5; // 5 = PRINTER
-  layer_color_ = current_layer_->color().name();
+  layer_color_ = current_layer_->color().name().toUpper();
   focus_adjust_ = current_layer_->focus();
   focus_step_ = current_layer_->focusStep();
   pwm_scale_ = 1 - current_layer_->minPower() / current_layer_->power();

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -438,13 +438,13 @@ void ToolpathExporterFcode::updateLayerParam() {
     layer_speed_sec_ = qMax(float(current_layer_->printingSpeed()), config_.min_speed);
     min_padding = config_.min_printing_padding;
     // Update submodule color
-    if (layer_color_ == "9FE3FF" || layer_color_ == "009FE3") {
+    if (layer_color_ == "#9FE3FF" || layer_color_ == "#009FE3") {
       submodule_color_ = "cyan";
-    } else if (layer_color_ == "E6007E") {
+    } else if (layer_color_ == "#E6007E") {
       submodule_color_ = "magenta";
-    } else if (layer_color_ == "FFED00") {
+    } else if (layer_color_ == "#FFED00") {
       submodule_color_ = "yellow";
-    } else if (layer_color_ == "E2E2E2") {
+    } else if (layer_color_ == "#E2E2E2") {
       submodule_color_ = "white";
     } else {
       submodule_color_ = "black";

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -92,6 +92,7 @@ struct Config {
   bool enable_multipass_compensation = false;
   bool enable_vector_speed_constraint = false;
   bool enable_relative_z_move = false;
+  bool enable_rotary_z_move = false;
   bool is_one_way_printing = false;
   bool is_diode_one_way_engraving = false;
   bool is_reverse_engraving = false;
@@ -174,6 +175,7 @@ class ToolpathExporterFcode : public QObject {
       with_module_ = true;
       config_.fg_pwm_limit = 0;
       config_.enable_relative_z_move = true;
+      config_.enable_rotary_z_move = true;
       if (is_rotary_task_) {
         height += 378.2;
       }

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -395,7 +395,7 @@ class ToolpathExporterFcode : public QObject {
   void getIntersectPoint(QLineF line, int position, QPointF* point);
   void handlePathWalk(QPointF point, bool should_emit);
 
-  void outputBitmapFcode(bool pwm_engraving = false);
+  void outputBitmapFcode(bool pwm_engraving = false, int downsample = 5);
   bool rasterBitmap(const QImage& layer_image, QRect bbox, bool pwm_engraving);
   bool rasterLine(const uchar* data_ptr,
                   int left_bound,
@@ -432,7 +432,7 @@ class ToolpathExporterFcode : public QObject {
   QVector<QRect> getBoundingBoxes(QImage* src,
                                   int merge_offset_x = 0,
                                   int merge_offset_y = 0,
-                                  int downsample = 1);
+                                  float downsample = 1);
 
   void pause(bool to_standby_position);
   void moveZ(float z);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -180,6 +180,7 @@ class ToolpathExporterFcode : public QObject {
       hardware_ = HardwareType::BB2;
       is_v2_ = true;
       config_.fg_pwm_limit = 0;
+      default_path_acc = 1000;
     } else {
       // default beambox
       hardware_ = HardwareType::Beambox;

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -137,6 +137,8 @@ class ToolpathExporterFcode : public QObject {
 
   float getTimeCost() { return gen_->get_time_cost(); }
 
+  QJsonObject getMetadata() { return gen_->get_metadata(); }
+
   bool convertStack(const QList<LayerPtr>& layers,
                     QProgressDialog* dialog = nullptr);
 
@@ -553,6 +555,7 @@ class ToolpathExporterFcode : public QObject {
   QLineF border_lines_[4];  // px; top, right, bottom, left
 
   // Updated during processing
+  bool is_handling_main_work_ = false;
   bool is_handling_bitmap_ = false;
   bool is_a_mode_ = false;
   bool rotary_wait_move_ = false;
@@ -568,4 +571,9 @@ class ToolpathExporterFcode : public QObject {
   // For 3d curve
   float curve_x_ = 0;
   float curve_y_ = 0;
+  // Metadata
+  float min_x_ = std::nanf("");
+  float max_x_ = std::nanf("");
+  float min_y_ = std::nanf("");
+  float max_y_ = std::nanf("");
 };


### PR DESCRIPTION
1. Fix loading bvg  
   - Fix order of filled layer and line layer separated from same layer and Remove default layer
   - Fix importing images with rotation
2. Fix f-code converter errors
   - Fix v2 preview key
   - Fix printing color mapping
   - Fix px-mm calculation for x direction 
   - Fix printing packet box size
3. Change parameter keys of f-code
4. Sync ghost/client updates
   - Update bboxes downsample
   - Fix stepwise z
   - Add job origin
   - Fix rotary for v1 and bb2
   - Update metadata