### PR TITLE
Add setScanaheadParams function and API

### DIFF
--- a/src/machine/machine.cpp
+++ b/src/machine/machine.cpp
@@ -649,3 +649,14 @@ void Machine::setCorrection(double scaleX,double scaleY,double bucketX,double bu
     }
   }
 }
+
+void Machine::setScanaheadParams(double worksize, double angle, double xOffset, double yOffset) {
+  if (motion_controller_) {
+    if (motion_controller_->type() == "BSL") {
+      ((BSLMotionController*)motion_controller_)->setScanaheadParams(worksize, angle, xOffset, yOffset);
+      qInfo() << "Machine::setScanaheadParams() - set" << worksize << angle << xOffset << yOffset;
+    } else {
+      qWarning() << "Machine::setScanaheadParams() - Not supported for this motion controller";
+    }
+  }
+}

--- a/src/machine/machine.h
+++ b/src/machine/machine.h
@@ -47,6 +47,7 @@ public:
   void setCustomOrigin(std::tuple<qreal, qreal, qreal> new_origin);
   void setSerialPort(QSerialPort &serial_port);
   void setCorrection(double scaleX, double scaleY, double bucketX, double bucketY, double paralleX, double paralleY, double trapeX, double trapeY);
+  void setScanaheadParams(double worksize, double angle, double xOffset, double yOffset);
   bool connectSerial(QString portName, int baudrate);
   void disconnect();
   int getStatusId();

--- a/src/periph/motion_controller/bsl_motion_controller.cpp
+++ b/src/periph/motion_controller/bsl_motion_controller.cpp
@@ -280,8 +280,6 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
         } else if (type == "W") {
             double workarea = value.toDouble();
             center_pos = workarea / 2;
-            lcs_set_scanahead_params(workarea, false, false, false, 0, 0, 0);
-            // qInfo() << "BSLM~::handleGcode() - Workarea set to " << workarea << "@" << getDebugTime();
         } else if (type == "D") {
             if (value == "0") {
                 QChar resolution = gcode.at(3);
@@ -656,6 +654,11 @@ bool BSLMotionController::resetState() {
 void BSLMotionController::setCorrection(double scaleX, double scaleY,double bucketX,double bucketY,double paralleX,double paralleY,double trapeX,double trapeY) {
   LCS2Error ret = lcs_set_manual_correction_params(scaleX, scaleY, bucketX, bucketY, paralleX, paralleY, trapeX, trapeY);
   qInfo() << "BSLM~::setCorrection() - Correction set result = " << getErrorString(ret);
+}
+
+void BSLMotionController::setScanaheadParams(double worksize, double angle, double xOffset, double yOffset) {
+  LCS2Error ret = lcs_set_scanahead_params(worksize, false, false, false, angle, xOffset, yOffset);
+  qInfo() << "BSLM~::setScanaheadParams() - Scanahead Params set result = " << getErrorString(ret);
 }
 
 BoardRunStatus BSLMotionController::getBoardStatus() {

--- a/src/periph/motion_controller/bsl_motion_controller.h
+++ b/src/periph/motion_controller/bsl_motion_controller.h
@@ -24,6 +24,7 @@ public:
   CmdSendResult sendCmdPacket(QPointer<Executor> executor, QString cmd_packet) override;
   QString getCurrentError() { return this->getErrorString(current_error_); }
   void setCorrection(double scaleX, double scaleY, double bucketX, double bucketY, double paralleX, double paralleY, double trapeX, double trapeY);
+  void setScanaheadParams(double worksize, double angle, double xOffset, double yOffset);
   BoardRunStatus getBoardStatus();
   bool isConnected() override;
 

--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -157,6 +157,13 @@ void SwiftrayServer::handleDeviceSpecificAction(QWebSocket* socket, const QStrin
     double trapeX = params.toObject()["trapeX"].toDouble();
     double trapeY = params.toObject()["trapeY"].toDouble();
     getMachine()->setCorrection(scaleX, scaleY, bucketX, bucketY, paralleX, paralleY, trapeX, trapeY); 
+  } else if (action == "setScanaheadParams") {
+    QJsonObject obj = params.toObject();
+    double worksize = obj["worksize"].toDouble();
+    double angle = obj["angle"].toDouble();
+    double xOffset = obj["xOffset"].toDouble();
+    double yOffset = obj["yOffset"].toDouble();
+    getMachine()->setScanaheadParams(worksize, angle, xOffset, yOffset);
   } else if (action == "setParam") {
     QString paramName = params.toObject()["name"].toString();
     QJsonValue paramValue = params.toObject()["value"];


### PR DESCRIPTION
# Description

1. Add setScanaheadParams in bsl_motion_controller.
2. Remove `lcs_set_scanahead_params` in gcode handler W case.
3. Add setScanaheadParams in swiftray server.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
