### PR TITLE
Fix motion_controller_ and m_canvas init value

### DIFF
--- a/src/machine/machine.h
+++ b/src/machine/machine.h
@@ -88,7 +88,7 @@ private:
   QSerialPort *serial_port_ = nullptr;
 
   // Hardware equipment controllers
-  MotionController *motion_controller_; // created when port connected
+  MotionController *motion_controller_ = nullptr; // created when port connected
   //AutofocusController *af_controller_;
   //CameraController *camera_controller_;
   

--- a/src/server/swiftray-server.h
+++ b/src/server/swiftray-server.h
@@ -24,7 +24,7 @@ private:
   QWebSocketServer* m_server;
   Machine* m_machine;
   QString m_buffer;
-  Canvas* m_canvas;
+  Canvas* m_canvas = nullptr;
   QString m_thumbnail;
   QStringList gcode_list_;
   QList<Timestamp> timestamp_list_;


### PR DESCRIPTION
# Description

Set some member pointer init value to nullptr since Windows may set them to 0xffffffff if not set.
(Only changed those may cause bug that I encountered.)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
