### PR TITLE
Support mopa red light preview

### DIFF
--- a/src/machine/machine.cpp
+++ b/src/machine/machine.cpp
@@ -129,9 +129,11 @@ bool Machine::createFramingJob(QStringList gcode_list) {
   if (!motion_controller_) {
     return false;
   }
-  if (motion_controller_->type() != "BSL") gcode_list.append("?"); // Request for realtime status update at the end of the job
+  bool is_bsl = motion_controller_->type() == "BSL";
+  if (is_bsl) gcode_list.insert(0, "M103"); // Custom gcode indicating framing for BSL machine
+  else gcode_list.append("?"); // Request for realtime status update at the end of the job
   auto job = QSharedPointer<FramingJob>::create(gcode_list);
-  if (motion_controller_->type() == "BSL") job->auto_loop = true; // If it's a galvanometer machine, run loop
+  if (is_bsl) job->auto_loop = true; // If it's a galvanometer machine, run loop
   return job_executor_ && job_executor_->setNewJob(job);
 }
 

--- a/src/periph/motion_controller/bsl_motion_controller.cpp
+++ b/src/periph/motion_controller/bsl_motion_controller.cpp
@@ -428,11 +428,9 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
       lcs_write_io_port(0b1111);
       dequeueCmd(1);
     } else if (command == "M103") {
-      // Indicate the job is a framing job
       is_framing = true;
       dequeueCmd(1);
     } else if (command == "M104") {
-      // Indicate the job is not a framing job
       is_framing = false;
       dequeueCmd(1);
     } else if (!is_move_command) {

--- a/src/periph/motion_controller/bsl_motion_controller.cpp
+++ b/src/periph/motion_controller/bsl_motion_controller.cpp
@@ -395,8 +395,6 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
       lcs_set_scanner_delays(100, 50);
       lcs_set_start_list(1);
       lcs_set_laser_power(100);
-      // only set red light to true only when framing for MOPA
-      qInfo() << "BSLM~::handleGcode() is_framing" << is_framing;
       lcs_set_laser_mode(LCS_MOPA, is_framing);
       lcs_enable_laser();
       lcs_error_count = 0;
@@ -432,6 +430,11 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
     } else if (command == "M103") {
       // Indicate the job is a framing job
       is_framing = true;
+      dequeueCmd(1);
+    } else if (command == "M104") {
+      // Indicate the job is not a framing job
+      is_framing = false;
+      dequeueCmd(1);
     } else if (!is_move_command) {
       dequeueCmd(1);
       return;
@@ -495,9 +498,7 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
       laser_enabled = false;
       should_end = false;
       lcs_disable_laser();
-      qInfo() << "Handle end, is_framing:\n" << is_framing << "\n";
       if (!is_framing) lcs_set_laser_control(false);
-      is_framing = false;
     }
 
     // Process move command

--- a/src/periph/motion_controller/bsl_motion_controller.cpp
+++ b/src/periph/motion_controller/bsl_motion_controller.cpp
@@ -211,6 +211,7 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
     static int d_buffer = 0;
     static int freq = 100; //100 khz
     static int pulse_width = 100; // 100 ns
+    static bool is_framing = false;
 
     // Skip these GCode
     if (gcode == "\u0018" || gcode == "$I\n" || gcode == "$H\n") {
@@ -394,7 +395,9 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
       lcs_set_scanner_delays(100, 50);
       lcs_set_start_list(1);
       lcs_set_laser_power(100);
-      lcs_set_laser_mode(LCS_MOPA, false);
+      // only set red light to true only when framing for MOPA
+      qInfo() << "BSLM~::handleGcode() is_framing" << is_framing;
+      lcs_set_laser_mode(LCS_MOPA, is_framing);
       lcs_enable_laser();
       lcs_error_count = 0;
       should_swap = false;
@@ -408,6 +411,14 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
     } else if (command == "M5") {
       qInfo() << "Turn Off Laser";
       dequeueCmd(1);
+    } else if (command == "M99" ) {
+      char sn[50];
+      lcs_get_serial_number(sn, 32);
+      qInfo() << "BSLM~::handleGcode() - Serial Number: " << sn;
+      if (sn[0] != '\0') {
+        Q_EMIT configUpdate("serial", sn);
+      }
+      dequeueCmd(1);
     } else if (command == "M100") { 
       rotary_mode = false;
       dequeueCmd(1);
@@ -418,14 +429,9 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
       qInfo() << "Enable OUT1/OUT2"; // Required for moving Z axis
       lcs_write_io_port(0b1111);
       dequeueCmd(1);
-    } else if (command == "M99" ) {
-      char sn[50];
-      lcs_get_serial_number(sn, 32);
-      qInfo() << "BSLM~::handleGcode() - Serial Number: " << sn;
-      if (sn[0] != '\0') {
-        Q_EMIT configUpdate("serial", sn);
-      }
-      dequeueCmd(1);
+    } else if (command == "M103") {
+      // Indicate the job is a framing job
+      is_framing = true;
     } else if (!is_move_command) {
       dequeueCmd(1);
       return;
@@ -489,7 +495,9 @@ void BSLMotionController::handleGcode(const QString &gcode, bool force_pulse) {
       laser_enabled = false;
       should_end = false;
       lcs_disable_laser();
-      lcs_set_laser_control(false);
+      qInfo() << "Handle end, is_framing:\n" << is_framing << "\n";
+      if (!is_framing) lcs_set_laser_control(false);
+      is_framing = false;
     }
 
     // Process move command

--- a/src/toolpath_exporter/generators/base-generator.h
+++ b/src/toolpath_exporter/generators/base-generator.h
@@ -56,6 +56,10 @@ public:
     qWarning() << "BaseGenerator::disableRotary()" << "Rotary feature not implemented"; 
   }
 
+  virtual void setRedLight(bool val) {
+    qWarning() << "BaseGenerator::setRedLight()" << "setRedLight not implemented"; 
+  }
+
   virtual void setFrequency(int frequency) {
     qWarning() << "BaseGenerator::setFrequency()" << "Rotary feature not implemented"; 
   }

--- a/src/toolpath_exporter/generators/gcode-generator.h
+++ b/src/toolpath_exporter/generators/gcode-generator.h
@@ -177,6 +177,10 @@ public:
     str_stream_ << "M100" << std::endl;
   }
 
+  void setRedLight(bool val) override {
+    str_stream_ << (val ? "M103" : "M104") << std::endl;
+  }
+
   void setWorkarea(QRectF workarea) override {
     str_stream_ << "W" << workarea.width() << std::endl;
   }

--- a/src/toolpath_exporter/toolpath-exporter.cpp
+++ b/src/toolpath_exporter/toolpath-exporter.cpp
@@ -33,6 +33,7 @@ bool ToolpathExporter::convertStack(const QList<LayerPtr> &layers, bool is_high_
   // Initial Setup
   if (!gen_->isRotaryMode()) {
     gen_->disableRotary();
+    gen_->setRedLight(false);
   }
   gen_->turnOffLaser(); // M5
   if(start_with_home) {


### PR DESCRIPTION
# Description

1. Add customized gcode M103, M104 to indicate using red light or not for Promark.
2. Add M103 in createFramingJob, M104 in toolpath-exporter.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
