### PR TITLE
Fix fcode and preview

### DIFF
--- a/src/toolpath_exporter/generators/fcode-generator.h
+++ b/src/toolpath_exporter/generators/fcode-generator.h
@@ -802,22 +802,22 @@ class FCodeGeneratorG : public FCodeGenerator {
               float s) {
     str_stream << "G1";
     if (flags & FCodeGenerator::move_flag_F && feedrate > 0) {
-      str_stream << "F" << feedrate;
+      str_stream << " F" << feedrate;
     }
     if (flags & FCodeGenerator::move_flag_X) {
-      str_stream << "X" << x;
+      str_stream << " X" << x;
     }
     if (flags & FCodeGenerator::move_flag_Y) {
-      str_stream << "Y" << y;
+      str_stream << " Y" << y;
     }
     if (flags & FCodeGenerator::move_flag_Z) {
-      str_stream << "Z" << z;
+      str_stream << " Z" << z;
     }
     if (flags & FCodeGenerator::move_flag_A) {
-      str_stream << "A" << a;
+      str_stream << " Y" << a;
     }
     if (flags & FCodeGenerator::move_flag_S) {
-      str_stream << "S" << s;
+      str_stream << " S" << s;
     }
     str_stream << "\n";
   }

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -608,6 +608,7 @@ void ToolpathExporterFcode::convertLaserLayer() {
   polygons_mutex_.unlock();
   is_handling_bitmap_ = false;
   layer_painter_ = std::make_unique<QPainter>(&laser_bitmap_);
+  layer_painter_->setClipRect(clip_area_);
   laser_bitmap_.fill(Qt::white);
   preview_painter_ = std::make_unique<QPainter>(&preview_bitmap_);
   preview_bitmap_.fill(Qt::white);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -333,7 +333,7 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
   }
 
   // Step 5. Handle printing test, prespray task if needed
-  if (is_v2_ && with_print_task_ && !config_.prespray.isEmpty()) {
+  if (!is_gcode_ && is_v2_ && with_print_task_ && !config_.prespray.isEmpty()) {
     // Mock layer param for printing dpmm and module offset
     layer_module_ = 5;
     is_printing_layer_ = true;

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -153,8 +153,8 @@ class ToolpathExporterFcode : public QObject {
       config_.job_origin = QPointF(param["job_origin"].toArray()[0].toDouble(),
                                    param["job_origin"].toArray()[1].toDouble());
     }
-    float spinning_axis_coord = param["spin"].toDouble();
-    if (spinning_axis_coord > 0) {
+    float spinning_axis_coord = param["spin"].toDouble(-1);
+    if (spinning_axis_coord >= 0) {
       is_rotary_task_ = true;
       config_.spinning_axis_coord = spinning_axis_coord / canvas_mm_ratio - config_.job_origin.y();
       rotary_y_ratio_ = param["rotary_y_ratio"].toDouble(1);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -117,6 +117,7 @@ class ToolpathExporterFcode : public QObject {
 
     QString type = param->value("type").toString();
     if (type == "gcode") {
+      is_gcode_ = true;
       gen = std::make_shared<FCodeGeneratorG>();
     } else if (is_v2_) {
       if (is_rotary_task_ || with_custom_origin_) {
@@ -521,6 +522,7 @@ class ToolpathExporterFcode : public QObject {
   HardwareType hardware_ = HardwareType::Beambox;
   NozzleSettings nozzle_settings;
   CurveEngravingSettings curve_settings;
+  bool is_gcode_ = false;
   bool is_v2_ = false;
   bool is_rotary_task_ = false;
   bool is_3d_task_ = false;


### PR DESCRIPTION
Fcode
1. Set clip area for laser bitmap
2. Allow spin coord at 0

Path Preview
1. Skip prespray task
2. Use Y instead of A in v2
3. Fix power on after printing in path preview 
(`G1S0` updates `g` value and `G1 S0` updates both `g` and `s` values in core tmpParseGcode.js)
