### PR TITLE
Progress and Cancel for beam studio api

### DIFF
--- a/src/executor/machine_job/machine_job.cpp
+++ b/src/executor/machine_job/machine_job.cpp
@@ -1,6 +1,7 @@
 #include "machine_job.h"
 
 #include <QtMath>
+#include <QCoreApplication>
 #include <QDebug>
 #include <executor/operation_cmd/gcode_cmd.h>
 
@@ -27,6 +28,7 @@ void MachineJob::setMotionController(QPointer<MotionController> motion_controlle
  * @retval Total time required in ms
  */
 double MachineJob::calcTotalTime(const QStringList& gcode_list) {
+  cancelled = false;
   // Controller constants
   double z_speed = 3; // mm/s lcs_set_axis_move(1, fabs(z) * 1600, z > 0, 4800, 10, 255);
   double jump_speed = 4000; // mm/s lcs_set_jump_speed_ctrl(4000);
@@ -42,8 +44,9 @@ double MachineJob::calcTotalTime(const QStringList& gcode_list) {
   int dotting_time = 0; // us
   bool hasEnd = false;
   double wobble_k = 1;
+  int batch_size = qMax(1000, gcode_list.size() / 30);
 
-  while (current_line < gcode_list.size() && !hasEnd) {
+  while (current_line < gcode_list.size() && !hasEnd && !cancelled) {
     QString line = gcode_list[current_line];
     line = line.toUpper();
     if (line.startsWith(";DOT", Qt::CaseSensitivity::CaseInsensitive)) {
@@ -153,6 +156,11 @@ double MachineJob::calcTotalTime(const QStringList& gcode_list) {
       }
     }
     current_line++;
+    if (current_line % batch_size == 0) {
+      // Use float calculation to avoid integer overflow on large gcode list
+      Q_EMIT progressChanged(100.0 * current_line / gcode_list.size());
+      QCoreApplication::processEvents();
+    }
   }
   return total_time;
 }

--- a/src/executor/machine_job/machine_job.h
+++ b/src/executor/machine_job/machine_job.h
@@ -24,6 +24,7 @@ public:
   int getIndex() const { return next_gcode_idx_; } 
   int length() const { return gcode_list_.length(); }
   QString getJobName() const { return job_name_; }
+  void handleCancel() { cancelled = true; }
 
   virtual Timestamp getElapsedTime() const;
   virtual Timestamp getTotalRequiredTime() const;
@@ -33,13 +34,18 @@ public:
   QPixmap getPreview() const;
   void setMotionController(QPointer<MotionController>);
 
-  static double calcTotalTime(const QStringList& gcode_list);
+  double calcTotalTime(const QStringList& gcode_list);
 
   static QList<Timestamp> calcRequiredTime(const QStringList &gcode_list,
                                           QPointer<QProgressDialog> progress_dialog);
   static QList<Timestamp> calcRequiredTime(QStringList &&gcode_list,
                                           QPointer<QProgressDialog> progress_dialog);
   bool auto_loop = false;
+  bool cancelled = false;
+
+Q_SIGNALS:
+  void progressChanged(int value);
+
 protected:
   QString job_name_;
   bool with_preview_ = false;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(Swiftray PRIVATE
     swiftray-server.cpp
+    worker.cpp
 )

--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -211,9 +211,8 @@ void SwiftrayServer::handleDeviceSpecificAction(QWebSocket* socket, const QStrin
     QString data = params.toObject()["data"].toString();
     if (data != "") {
       gcode_list_ = data.split("\n");
-      timestamp_list_ = QList<Timestamp>();
     }
-    bool job_result = getMachine()->createGCodeJob(gcode_list_, timestamp_list_);
+    bool job_result = getMachine()->createGCodeJob(gcode_list_, QList<Timestamp>());
     qInfo() << "Job created" << job_result;
     result["success"] = job_result;
   } else if (action == "sendGCode") {

--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -2,11 +2,13 @@
 #include "liblcs/lcsExpr.h"
 #undef _HAS_STD_BYTE
 #include "swiftray-server.h"
+#include "worker.h"
 #include <cmath>
 #include <canvas/canvas.h>
 #include <toolpath_exporter/generators/dirty-area-outline-generator.h>
 #include <toolpath_exporter/toolpath-exporter.h>
 #include <toolpath_exporter/toolpath-exporter-fcode.h>
+#include <QCoreApplication>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -247,94 +249,16 @@ bool SwiftrayServer::handleParserAction(QWebSocket* socket, const QString& id, c
   QJsonObject result;
   result["success"] = true;
 
-  if (action == "loadSVG") {
-    // Implement BVG data loading logic
-    if (m_canvas != nullptr) {
-      delete m_canvas;
+  if (action == "interrupt") {
+    if (workerThread != nullptr) {
+      Q_EMIT interruptWorker();
+      QCoreApplication::processEvents();
     }
-    QJsonObject params_obj = params.toObject();
-    QJsonObject wrapped_file = params_obj["file"].toObject();
-    QString svg_data = wrapped_file["data"].toString().toUtf8();
-    this->m_canvas = new Canvas();
-    this->m_thumbnail = wrapped_file["thumbnail"].toString();
-    this->m_rotary_mode = params_obj["rotaryMode"].toBool();
-    this->m_engrave_dpi = params_obj["engraveDpi"].toInt();
-    QJsonObject default_config = params_obj["defaultConfig"].toObject();
-    QByteArray svg_data_bytes = QByteArray::fromStdString(svg_data.toStdString());
-    this->m_canvas->loadSVG(svg_data_bytes, true, default_config);
-    qInfo() << "SVG data loaded" << svg_data.length();
-    result["loadedDataSize"] = svg_data_bytes.length();
-  } else if (action == "convert") {
-    // Get the parameters
-    QJsonObject params_obj = params.toObject();
-    QJsonObject workarea = params_obj["workarea"].toObject();
-    MachineSettings::MachineParam machine_param;
-    machine_param.width = workarea["width"].toInt();
-    machine_param.height = workarea["height"].toInt();
-    int travel_speed = fmax(params_obj["travelSpeed"].toInt(), 20);
-    QString type = params_obj["type"].toString();
-    bool is_promark = params_obj["isPromark"].toBool();
-    if (!is_promark) {
-      qInfo() << "Generating Task Code... TYPE" << type << "DPI" << this->m_engrave_dpi;
-      QTransform move_translate = QTransform();
-      ToolpathExporterFcode exporter(move_translate, m_engrave_dpi, &params_obj, &m_thumbnail);
-      bool completed = exporter.convertStack(m_canvas->document().layers(), nullptr);
-      if (!completed) {
-        return false;
-      }
-      if (type == "fcode") {
-        result["fcode"] = QString(QByteArray::fromStdString(exporter.toString()).toBase64());
-        result["timeCost"] = exporter.getTimeCost();
-        result["metadata"] = exporter.getMetadata();
-      } else {
-        result["gcode"] = QString::fromStdString(exporter.toString());
-      }
-      result["fileName"] = "swiftray-conversion";
-    } else {
-      qInfo() << "Generating Promark GCode..." << "DPI" << this->m_engrave_dpi << "ROTARY" << this->m_rotary_mode << "TRAVEL" << travel_speed;
-      bool use_fast_gradient = params_obj["shouldUseFastGradient"].toBool();
-      bool enable_high_speed = (m_machine == NULL || this->m_machine->getMachineParam().is_high_speed_mode) && m_canvas->hasBitmap() && use_fast_gradient;
-      // Generate GCode
-      GCodeGenerator gen(machine_param, this->m_rotary_mode);
-      QTransform move_translate = QTransform();
-      auto origin = m_machine == nullptr ? std::make_tuple<qreal, qreal, qreal>(0, 0, 0) : m_machine->getCustomOrigin();
-      ToolpathExporter exporter(
-          (BaseGenerator*)&gen,
-          this->m_engrave_dpi / 25.4,
-          travel_speed,
-          QPointF(std::get<0>(origin), std::get<1>(origin)),
-          ToolpathExporter::PaddingType::kNoPadding,
-          move_translate);
-      exporter.setSortRule(PathSort::NestedSort);
-      exporter.setWorkAreaSize(QRectF(0, 0, m_canvas->document().width() / 10, m_canvas->document().height() / 10));
-
-      if ( true != exporter.convertStack(m_canvas->document().layers(), enable_high_speed, true)) {
-        return false; // canceled
-      }
-      if (exporter.isExceedingBoundary()) {
-        qWarning() << "Some items aren't placed fully inside the working area.";
-      }
-      if (this->m_rotary_mode && m_canvas->calculateShapeBoundary().height() > m_canvas->document().height()) {
-        qInfo() << "Rotary mode is enabled, but the height of the design is larger than the working area.";
-      }
-      qInfo() << "Conversion completed.";
-      m_buffer = QString::fromStdString(gen.toString());
-      // Write m_buffer to file
-      QFile file("swiftray-conversion.gcode");
-      if (file.open(QIODevice::WriteOnly)) {
-        QTextStream stream(&file);
-        stream << m_buffer;
-        file.close();
-      }
-      gcode_list_ = m_buffer.split("\n");
-      result["gcode"] = m_buffer;
-      result["fileName"] = "swiftray-conversion";
-      this->m_time_cost = MachineJob::calcTotalTime(gcode_list_)/1000;
-      result["timeCost"] = this->m_time_cost;
-      qInfo() << "GCode generation completed." << m_buffer.length() << "time estimate" << this->m_time_cost;
-      // Debugging GCode
-      if (m_buffer.length() < 3000) printf("%s", m_buffer.toStdString().c_str());
-    }
+  } else if (action == "loadSVG" || action == "convert") {
+    setupWorker();
+    Q_EMIT sendTaskToWorker(socket, id, action, params);
+    QCoreApplication::processEvents();
+    return true;
   } else if (action == "loadSettings") {
     // Implement settings loading logic
   } else {
@@ -365,6 +289,17 @@ void SwiftrayServer::handleSystemAction(QWebSocket* socket, const QString& id, c
   }
 
   sendCallback(socket, id, result);
+}
+
+void SwiftrayServer::sendData(QWebSocket* socket, const QString& id, const QJsonObject& result, const QString& type) {
+  QJsonObject payload;
+  payload["id"] = id;
+  payload["result"] = result;
+  payload["type"] = type;
+  QJsonDocument doc(payload);
+  QString msg = doc.toJson(QJsonDocument::Compact);
+  socket->sendTextMessage(msg);
+  socket->flush();
 }
 
 void SwiftrayServer::sendCallback(QWebSocket* socket, const QString& id, const QJsonObject& result) {
@@ -426,6 +361,8 @@ QJsonArray SwiftrayServer::getDeviceList() {
   return devices;
 }
 
+// TODO: split to 'generate task' and 'start job'
+// And move generation part to worker for AreaCheck framing
 bool SwiftrayServer::startFraming(QJsonArray points, int width) {
   qInfo() << "Starting framing job" << points << "width:" << width;
   if (getMachine()->getJobExecutor()->getActiveJob()) {
@@ -472,4 +409,20 @@ bool SwiftrayServer::startFraming(QJsonArray points, int width) {
     return true;
   }
   return false;
+}
+
+void SwiftrayServer::setupWorker() {
+  if (workerThread == nullptr) {
+    qInfo() << "Setup worker thread";
+    workerThread = new QThread(this);
+    worker = new Worker(this);
+
+    connect(this, &SwiftrayServer::interruptWorker, worker, &Worker::handleInterrupt, Qt::QueuedConnection);
+    connect(this, &SwiftrayServer::sendTaskToWorker, worker, &Worker::handleAction, Qt::QueuedConnection);
+    connect(worker, &Worker::sendDataInMain, this, &SwiftrayServer::sendData, Qt::QueuedConnection);
+    connect(worker, &Worker::sendCallbackInMain, this, &SwiftrayServer::sendCallback, Qt::QueuedConnection);
+
+    worker->moveToThread(workerThread);
+    workerThread->start();
+  }
 }

--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -66,6 +66,7 @@ void SwiftrayServer::onNewConnection() {
   qInfo() << "New connection from" << socket->peerAddress().toString();
   
   connect(socket, &QWebSocket::textMessageReceived, this, &SwiftrayServer::processMessage);
+  connect(socket, &QWebSocket::binaryMessageReceived, this, &SwiftrayServer::processBinaryMessage);
   connect(socket, &QWebSocket::disconnected, socket, &QWebSocket::deleteLater);
 }
 
@@ -106,6 +107,11 @@ void SwiftrayServer::processMessage(const QString& message) {
       sendCallback(socket, id, QJsonObject{{"success", false}, {"error", "Unknown error"}});
     }
   }
+}
+
+void SwiftrayServer::processBinaryMessage(const QByteArray& message) {
+  QString text = QString::fromUtf8(message);
+  processMessage(text);
 }
 
 void SwiftrayServer::handleDevicesAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params) {

--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -28,6 +28,7 @@ SwiftrayServer::SwiftrayServer(quint16 port, QObject* parent)
   } else {
     qCritical() << "Failed to start Swiftray Server on port" << port;
   }
+  setupWorker();
 }
 
 Machine* SwiftrayServer::getMachine() {
@@ -63,11 +64,20 @@ Machine* SwiftrayServer::getMachine() {
 
 void SwiftrayServer::onNewConnection() {
   QWebSocket* socket = m_server->nextPendingConnection();
+  QPointer<QWebSocket> socket_ptr = socket;
   qInfo() << "New connection from" << socket->peerAddress().toString();
   
   connect(socket, &QWebSocket::textMessageReceived, this, &SwiftrayServer::processMessage);
   connect(socket, &QWebSocket::binaryMessageReceived, this, &SwiftrayServer::processBinaryMessage);
   connect(socket, &QWebSocket::disconnected, socket, &QWebSocket::deleteLater);
+  connect(socket, &QWebSocket::disconnected, [&, socket_ptr]() {
+    if (workerThread != nullptr) {
+      // Note: socket object maybe deleted worker handling the interrupt
+      // Use QPointer to avoid accessing deleted object
+      Q_EMIT interruptWorker(socket_ptr);
+      QCoreApplication::processEvents();
+    }
+  });
 }
 
 void SwiftrayServer::processMessage(const QString& message) {
@@ -256,11 +266,11 @@ bool SwiftrayServer::handleParserAction(QWebSocket* socket, const QString& id, c
 
   if (action == "interrupt") {
     if (workerThread != nullptr) {
-      Q_EMIT interruptWorker();
+      QPointer<QWebSocket> socket_ptr = socket;
+      Q_EMIT interruptWorker(socket_ptr);
       QCoreApplication::processEvents();
     }
   } else if (action == "loadSVG" || action == "convert") {
-    setupWorker();
     Q_EMIT sendTaskToWorker(socket, id, action, params);
     QCoreApplication::processEvents();
     return true;
@@ -297,6 +307,7 @@ void SwiftrayServer::handleSystemAction(QWebSocket* socket, const QString& id, c
 }
 
 void SwiftrayServer::sendData(QWebSocket* socket, const QString& id, const QJsonObject& result, const QString& type) {
+  if (!socket->isValid()) return;
   QJsonObject payload;
   payload["id"] = id;
   payload["result"] = result;
@@ -308,6 +319,7 @@ void SwiftrayServer::sendData(QWebSocket* socket, const QString& id, const QJson
 }
 
 void SwiftrayServer::sendCallback(QWebSocket* socket, const QString& id, const QJsonObject& result) {
+  if (!socket->isValid()) return;
   QJsonObject callback;
   callback["id"] = id;
   callback["result"] = result;
@@ -319,6 +331,7 @@ void SwiftrayServer::sendCallback(QWebSocket* socket, const QString& id, const Q
 }
 
 void SwiftrayServer::sendEvent(QWebSocket* socket, const QString& event, const QJsonObject& data) {
+  if (!socket->isValid()) return;
   QJsonObject payload;
   payload["type"] = event;
   payload["data"] = data;

--- a/src/server/swiftray-server.h
+++ b/src/server/swiftray-server.h
@@ -36,6 +36,7 @@ private:
   bool m_rotary_mode;
   int m_engrave_dpi;
   double m_time_cost = 0;
+  std::mutex canvas_mutex_;
   QThread* workerThread;
   Worker* worker;
   friend class Worker;

--- a/src/server/swiftray-server.h
+++ b/src/server/swiftray-server.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "worker.h"
 #include <QObject>
 #include <QWebSocketServer>
 #include <QWebSocket>
@@ -19,27 +20,35 @@ private Q_SLOTS:
   void onNewConnection();
   void processMessage(const QString& message);
 
-private:
-  QMap<QString, Machine*> machine_map_;
-  QWebSocketServer* m_server;
+Q_SIGNALS:
+  void interruptWorker();
+  void sendTaskToWorker(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
+
+// Expose variables to Worker
   Machine* m_machine;
   QString m_buffer;
   Canvas* m_canvas = nullptr;
   QString m_thumbnail;
   QStringList gcode_list_;
-  QList<Timestamp> timestamp_list_;
-
   bool m_rotary_mode;
   int m_engrave_dpi;
   double m_time_cost = 0;
+
+private:
+  QMap<QString, Machine*> machine_map_;
+  QWebSocketServer* m_server;
+  QThread* workerThread;
+  Worker* worker;
 
   void handleDevicesAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
   void handleDeviceSpecificAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params, const QString& port);
   bool handleParserAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
   void handleSystemAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
+  void sendData(QWebSocket* socket, const QString& id, const QJsonObject& result, const QString& type);
   void sendCallback(QWebSocket* socket, const QString& id, const QJsonObject& result);
   void sendEvent(QWebSocket* socket, const QString& event, const QJsonObject& data);
   bool startFraming(QJsonArray points, int width);
+  void setupWorker();
   Machine* getMachine();
   QJsonArray getDeviceList();
 };

--- a/src/server/swiftray-server.h
+++ b/src/server/swiftray-server.h
@@ -22,7 +22,7 @@ private Q_SLOTS:
   void processBinaryMessage(const QByteArray& message);
 
 Q_SIGNALS:
-  void interruptWorker();
+  void interruptWorker(QPointer<QWebSocket> socket_ptr);
   void sendTaskToWorker(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
 
 private:
@@ -37,7 +37,7 @@ private:
   int m_engrave_dpi;
   double m_time_cost = 0;
   std::mutex canvas_mutex_;
-  QThread* workerThread;
+  QThread* workerThread = nullptr;
   Worker* worker;
   friend class Worker;
 

--- a/src/server/swiftray-server.h
+++ b/src/server/swiftray-server.h
@@ -19,6 +19,7 @@ public:
 private Q_SLOTS:
   void onNewConnection();
   void processMessage(const QString& message);
+  void processBinaryMessage(const QByteArray& message);
 
 Q_SIGNALS:
   void interruptWorker();

--- a/src/server/swiftray-server.h
+++ b/src/server/swiftray-server.h
@@ -24,7 +24,9 @@ Q_SIGNALS:
   void interruptWorker();
   void sendTaskToWorker(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
 
-// Expose variables to Worker
+private:
+  QMap<QString, Machine*> machine_map_;
+  QWebSocketServer* m_server;
   Machine* m_machine;
   QString m_buffer;
   Canvas* m_canvas = nullptr;
@@ -33,12 +35,9 @@ Q_SIGNALS:
   bool m_rotary_mode;
   int m_engrave_dpi;
   double m_time_cost = 0;
-
-private:
-  QMap<QString, Machine*> machine_map_;
-  QWebSocketServer* m_server;
   QThread* workerThread;
   Worker* worker;
+  friend class Worker;
 
   void handleDevicesAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
   void handleDeviceSpecificAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params, const QString& port);

--- a/src/server/worker.cpp
+++ b/src/server/worker.cpp
@@ -11,9 +11,11 @@ Worker::Worker(QObject* server) {
   server_ = dynamic_cast<SwiftrayServer*>(server);
 }
 
-void Worker::handleInterrupt() {
-  Q_EMIT interruptAction();
-  QCoreApplication::processEvents();
+void Worker::handleInterrupt(QPointer<QWebSocket> socket_ptr) {
+  if (socket_ptr_.isNull() || socket_ptr_ == socket_ptr) {
+    Q_EMIT interruptAction();
+    QCoreApplication::processEvents();
+  }
 }
 
 bool Worker::handleAction(QWebSocket* socket,
@@ -28,9 +30,11 @@ bool Worker::handleAction(QWebSocket* socket,
     QCoreApplication::processEvents();
     return false;
   }
+  socket_ptr_ = socket;
   result["success"] = true;
   QString current_task = "";
   auto onProgress = [&](int prog) {
+    if (socket_ptr_.isNull()) return;
     Q_EMIT sendDataInMain(socket,
                           id,
                           QJsonObject{{"message", current_task},
@@ -39,6 +43,7 @@ bool Worker::handleAction(QWebSocket* socket,
     QCoreApplication::processEvents();
   };
   auto onCancel = [&]() {
+    if (socket_ptr_.isNull()) return;
     server_->canvas_mutex_.unlock();
     result["success"] = false;
     result["error"] = QJsonObject{{"message", "cancel"}},
@@ -171,6 +176,7 @@ bool Worker::handleAction(QWebSocket* socket,
     result["error"] = QJsonObject{{"message", "unknown action"}};
   }
 
+  if (socket_ptr_.isNull()) return false;
   Q_EMIT sendCallbackInMain(socket, id, result);
   QCoreApplication::processEvents();
   server_->canvas_mutex_.unlock();

--- a/src/server/worker.cpp
+++ b/src/server/worker.cpp
@@ -21,6 +21,13 @@ bool Worker::handleAction(QWebSocket* socket,
                           const QString& action,
                           const QJsonValue& params) {
   QJsonObject result;
+  if (!server_->canvas_mutex_.try_lock()) {
+    result["success"] = false;
+    result["error"] = QJsonObject{{"message", "The backend is currently busy. Please try again later."}},
+    Q_EMIT sendCallbackInMain(socket, id, result);
+    QCoreApplication::processEvents();
+    return false;
+  }
   result["success"] = true;
   QString current_task = "";
   auto onProgress = [&](int prog) {
@@ -32,6 +39,7 @@ bool Worker::handleAction(QWebSocket* socket,
     QCoreApplication::processEvents();
   };
   auto onCancel = [&]() {
+    server_->canvas_mutex_.unlock();
     result["success"] = false;
     result["error"] = QJsonObject{{"message", "cancel"}},
     Q_EMIT sendCallbackInMain(socket, id, result);
@@ -165,5 +173,6 @@ bool Worker::handleAction(QWebSocket* socket,
 
   Q_EMIT sendCallbackInMain(socket, id, result);
   QCoreApplication::processEvents();
+  server_->canvas_mutex_.unlock();
   return true;
 }

--- a/src/server/worker.cpp
+++ b/src/server/worker.cpp
@@ -43,8 +43,8 @@ bool Worker::handleAction(QWebSocket* socket,
     QCoreApplication::processEvents();
   };
   auto onCancel = [&]() {
-    if (socket_ptr_.isNull()) return;
     server_->canvas_mutex_.unlock();
+    if (socket_ptr_.isNull()) return;
     result["success"] = false;
     result["error"] = QJsonObject{{"message", "cancel"}},
     Q_EMIT sendCallbackInMain(socket, id, result);
@@ -176,9 +176,9 @@ bool Worker::handleAction(QWebSocket* socket,
     result["error"] = QJsonObject{{"message", "unknown action"}};
   }
 
+  server_->canvas_mutex_.unlock();
   if (socket_ptr_.isNull()) return false;
   Q_EMIT sendCallbackInMain(socket, id, result);
   QCoreApplication::processEvents();
-  server_->canvas_mutex_.unlock();
   return true;
 }

--- a/src/server/worker.cpp
+++ b/src/server/worker.cpp
@@ -111,7 +111,7 @@ bool Worker::handleAction(QWebSocket* socket,
       // Generate GCode
       GCodeGenerator gen(machine_param, server_->m_rotary_mode);
       QTransform move_translate = QTransform();
-      auto origin = m_machine == nullptr ? std::make_tuple<qreal, qreal, qreal>(0, 0, 0) : server_->m_machine->getCustomOrigin();
+      auto origin = server_->m_machine == nullptr ? std::make_tuple<qreal, qreal, qreal>(0, 0, 0) : server_->m_machine->getCustomOrigin();
       ToolpathExporter exporter(
           (BaseGenerator*)&gen,
           server_->m_engrave_dpi / 25.4,

--- a/src/server/worker.cpp
+++ b/src/server/worker.cpp
@@ -1,0 +1,169 @@
+#include "worker.h"
+#include "swiftray-server.h"
+#include <QCoreApplication>
+#include <QJsonObject>
+#include <executor/machine_job/machine_job.h>
+#include <toolpath_exporter/toolpath-exporter-fcode.h>
+#include <toolpath_exporter/toolpath-exporter.h>
+
+SwiftrayServer* server_;
+Worker::Worker(QObject* server) {
+  server_ = dynamic_cast<SwiftrayServer*>(server);
+}
+
+void Worker::handleInterrupt() {
+  Q_EMIT interruptAction();
+  QCoreApplication::processEvents();
+}
+
+bool Worker::handleAction(QWebSocket* socket,
+                          const QString& id,
+                          const QString& action,
+                          const QJsonValue& params) {
+  QJsonObject result;
+  result["success"] = true;
+  QString current_task = "";
+  auto onProgress = [&](int prog) {
+    Q_EMIT sendDataInMain(socket,
+                          id,
+                          QJsonObject{{"message", current_task},
+                                      {"percentage", float(prog) / 100}},
+                          "progress");
+    QCoreApplication::processEvents();
+  };
+  auto onCancel = [&]() {
+    result["success"] = false;
+    result["error"] = QJsonObject{{"message", "cancel"}},
+    Q_EMIT sendCallbackInMain(socket, id, result);
+    QCoreApplication::processEvents();
+  };
+
+  if (action == "loadSVG") {
+    // TODO: add progress and cancel support
+    // Implement BVG data loading logic
+    if (server_->m_canvas != nullptr) {
+      delete server_->m_canvas;
+    }
+    QJsonObject params_obj = params.toObject();
+    QJsonObject wrapped_file = params_obj["file"].toObject();
+    QString svg_data = wrapped_file["data"].toString().toUtf8();
+    server_->m_canvas = new Canvas();
+    server_->m_thumbnail = wrapped_file["thumbnail"].toString();
+    server_->m_rotary_mode = params_obj["rotaryMode"].toBool();
+    server_->m_engrave_dpi = params_obj["engraveDpi"].toInt();
+    QJsonObject default_config = params_obj["defaultConfig"].toObject();
+    QByteArray svg_data_bytes = QByteArray::fromStdString(svg_data.toStdString());
+    server_->m_canvas->loadSVG(svg_data_bytes, true, default_config);
+    qInfo() << "SVG data loaded" << svg_data.length();
+    result["loadedDataSize"] = svg_data_bytes.length();
+  } else if (action == "convert") {
+    // Get the parameters
+    QJsonObject params_obj = params.toObject();
+    QJsonObject workarea = params_obj["workarea"].toObject();
+    MachineSettings::MachineParam machine_param;
+    machine_param.width = workarea["width"].toInt();
+    machine_param.height = workarea["height"].toInt();
+    int travel_speed = fmax(params_obj["travelSpeed"].toInt(), 20);
+    QString type = params_obj["type"].toString();
+    bool is_promark = params_obj["isPromark"].toBool();
+    if (!is_promark) {
+      qInfo() << "Generating Task Code... TYPE" << type << "DPI" << server_->m_engrave_dpi;
+      QTransform move_translate = QTransform();
+      ToolpathExporterFcode exporter(move_translate, server_->m_engrave_dpi, &params_obj, &server_->m_thumbnail);
+      current_task = type == "gcode" ? "Generating Task Path..." : "Generating Task Code...";
+      onProgress(0);
+      connect(this, &Worker::interruptAction, &exporter, &ToolpathExporterFcode::handleCancel, Qt::QueuedConnection);
+      connect(&exporter, &ToolpathExporterFcode::progressChanged, onProgress);
+      bool completed = exporter.convertStack(server_->m_canvas->document().layers(), nullptr);
+      disconnect(&exporter);
+      exporter.disconnect();
+      if (!completed) {
+        onCancel();
+        return false;
+      }
+      if (type == "fcode") {
+        QString fcode(QByteArray::fromStdString(exporter.toString()).toBase64());
+        int max_chunk_size = 4096;
+        if (fcode.length() > max_chunk_size) {
+          qInfo() << "FCode is too large, sending as chunks" << fcode.length();
+          for (int i = 0; i < fcode.length(); i += max_chunk_size) {
+            result["chunk"] = fcode.mid(i, max_chunk_size);
+            Q_EMIT sendDataInMain(socket, id, result, "chunk");
+          }
+          result.remove("chunk");
+        } else {
+          result["fcode"] = fcode;
+        }
+        result["timeCost"] = exporter.getTimeCost();
+        result["metadata"] = exporter.getMetadata();
+      } else if (type == "preview") {
+        // Return task time for path preview
+        result["timeCost"] = exporter.getTimeCost();
+        result["metadata"] = exporter.getMetadata();
+      } else {
+        result["gcode"] = QString::fromStdString(exporter.toString());
+      }
+      result["fileName"] = "swiftray-conversion";
+    } else {
+      qInfo() << "Generating Promark GCode..." << "DPI" << server_->m_engrave_dpi << "ROTARY" << server_->m_rotary_mode << "TRAVEL" << travel_speed;
+      bool use_fast_gradient = params_obj["shouldUseFastGradient"].toBool();
+      bool enable_high_speed = (server_->m_machine == NULL || server_->m_machine->getMachineParam().is_high_speed_mode) && server_->m_canvas->hasBitmap() && use_fast_gradient;
+      // Generate GCode
+      GCodeGenerator gen(machine_param, server_->m_rotary_mode);
+      QTransform move_translate = QTransform();
+      auto origin = m_machine == nullptr ? std::make_tuple<qreal, qreal, qreal>(0, 0, 0) : server_->m_machine->getCustomOrigin();
+      ToolpathExporter exporter(
+          (BaseGenerator*)&gen,
+          server_->m_engrave_dpi / 25.4,
+          travel_speed,
+          QPointF(std::get<0>(origin), std::get<1>(origin)),
+          ToolpathExporter::PaddingType::kNoPadding,
+          move_translate);
+      exporter.setSortRule(PathSort::NestedSort);
+      exporter.setWorkAreaSize(QRectF(0, 0, server_->m_canvas->document().width() / 10, server_->m_canvas->document().height() / 10));
+
+      current_task = "Generating Task Code...";
+      onProgress(0);
+      connect(this, &Worker::interruptAction, &exporter, &ToolpathExporter::handleCancel, Qt::QueuedConnection);
+      connect(&exporter, &ToolpathExporter::progressChanged, onProgress);
+      if (true != exporter.convertStack(server_->m_canvas->document().layers(), enable_high_speed, true)) {
+        onCancel();
+        return false; // canceled
+      }
+      disconnect(&exporter);
+      exporter.disconnect();
+      if (exporter.isExceedingBoundary()) {
+        qWarning() << "Some items aren't placed fully inside the working area.";
+      }
+      if (server_->m_rotary_mode && server_->m_canvas->calculateShapeBoundary().height() > server_->m_canvas->document().height()) {
+        qInfo() << "Rotary mode is enabled, but the height of the design is larger than the working area.";
+      }
+      qInfo() << "Conversion completed.";
+      server_->m_buffer = QString::fromStdString(gen.toString());
+      server_->gcode_list_ = server_->m_buffer.split("\n");
+      current_task = "Calculating Task Time...";
+      onProgress(0);
+      MachineJob job;
+      connect(this, &Worker::interruptAction, &job, &MachineJob::handleCancel, Qt::QueuedConnection);
+      connect(&job, &MachineJob::progressChanged, this, onProgress);
+      server_->m_time_cost = job.calcTotalTime(server_->gcode_list_) / 1000;
+      disconnect(&job);
+      job.disconnect();
+      if (job.cancelled) {
+        onCancel();
+        return false;
+      }
+      result["gcode"] = server_->m_buffer;
+      result["fileName"] = "swiftray-conversion";
+      result["timeCost"] = server_->m_time_cost;
+      qInfo() << "GCode generation completed." << server_->m_buffer.length() << "time estimate" << server_->m_time_cost;
+    }
+  } else {
+    result["success"] = false;
+    result["error"] = QJsonObject{{"message", "unknown action"}};
+  }
+
+  Q_EMIT sendCallbackInMain(socket, id, result);
+  QCoreApplication::processEvents();
+  return true;
+}

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QObject>
+#include <QWebSocket>
+
+#include <canvas/canvas.h>
+#include <toolpath_exporter/generators/gcode-generator.h>
+
+// Handling long-time actions
+class Worker : public QObject {
+  Q_OBJECT
+
+ public:
+  Worker(QObject* parent);
+  void handleInterrupt();
+  bool handleAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
+
+ Q_SIGNALS:
+  void interruptAction();
+  void sendDataInMain(QWebSocket* socket, const QString& id, const QJsonObject& result, const QString& type);
+  void sendCallbackInMain(QWebSocket* socket, const QString& id, const QJsonObject& result);
+};

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -13,11 +13,14 @@ class Worker : public QObject {
 
  public:
   Worker(QObject* parent);
-  void handleInterrupt();
+  void handleInterrupt(QPointer<QWebSocket> socket_ptr);
   bool handleAction(QWebSocket* socket, const QString& id, const QString& action, const QJsonValue& params);
 
  Q_SIGNALS:
   void interruptAction();
   void sendDataInMain(QWebSocket* socket, const QString& id, const QJsonObject& result, const QString& type);
   void sendCallbackInMain(QWebSocket* socket, const QString& id, const QJsonObject& result);
+
+ private:
+  QPointer<QWebSocket> socket_ptr_;
 };

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -78,10 +78,12 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
   QElapsedTimer t;
   t.start();
   Q_ASSERT_X(!layers.empty(), "ToolpathExporterFcode", "Must input at least one layer");
+  total_layer_cnt_ = layers.size();
 
-  bool canceled = false;
+  progress_ = 0;
+  dialog_ = dialog;
   if (dialog != nullptr) {
-    connect(dialog, &QProgressDialog::canceled, [&]() { canceled = true; });
+    connect(dialog, &QProgressDialog::canceled, this, &ToolpathExporterFcode::handleCancel);
   }
 
   // Step 2. Handle pre-task
@@ -153,7 +155,7 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
   if (is_v2_) {
     gen_->end_task_script_block();
   }
-  if (canceled) {
+  if (cancelled_) {
     return false;
   }
 
@@ -174,8 +176,7 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
   qInfo() << "preview_bitmap_" << preview_bitmap_.size();
 
   // Step 4. Handle each layer
-  int processed_layer_cnt = 0;
-  int visible_layer_cnt = 1;
+  int visible_layer_cnt = 1; // v2 task info
   int last_module;
   QString last_color;
   QString last_sub_type;
@@ -183,7 +184,14 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
   for (auto layer_rit = layers.crbegin(); layer_rit != layers.crend();
        layer_rit++) {
     qInfo() << "[Export] Output layer: " << (*layer_rit)->name();
-    if ((*layer_rit)->isVisible() && (*layer_rit)->repeat() > 0) {
+    total_repeat_times_ = (*layer_rit)->repeat();
+    processed_repeat_times_ = 0;
+    if ((*layer_rit)->isVisible() && total_repeat_times_ > 0) {
+      if (cancelled_) {
+        return false;
+      }
+      onProgressChanged(0, true);
+
       current_layer_ = *layer_rit;
       updateLayerParam();
 
@@ -263,12 +271,11 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
         gen_->set_toolhead_pwm(0);
         moveto(std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""), 0);
       } else {
-        int repeat = current_layer_->repeat();
-        for (int i = 0; i < repeat; i++) {
-          if (has_focus_adjust_ && focus_step_ > 0 && i > 0) {
+        for (processed_repeat_times_ = 0; processed_repeat_times_ < total_repeat_times_; processed_repeat_times_++) {
+          if (has_focus_adjust_ && focus_step_ > 0 && processed_repeat_times_ > 0) {
             gen_->sync_motion_type2(184, 128, focus_step_);
           } else if (config_.enable_autofocus && layer_height > 0) {
-            double target_z = 17.0 - layer_height - config_.z_offset + i * layer_z_step;
+            double target_z = 17.0 - layer_height - config_.z_offset + processed_repeat_times_ * layer_z_step;
             target_z = round(qMax(qMin(target_z, 17.0), 0.0) * 100) / 100;
             moveZ(target_z);
           }
@@ -276,8 +283,8 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
           gen_->set_toolhead_pwm(0);
         }
         moveto(std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""), 0);
-        if (has_focus_adjust_ && focus_step_ > 0 && repeat > 1) {
-          float total_step = focus_step_ * (repeat - 1);
+        if (has_focus_adjust_ && focus_step_ > 0 && total_repeat_times_ > 1) {
+          float total_step = focus_step_ * (total_repeat_times_ - 1);
           gen_->sync_motion_type2(184, 128, -total_step);
         }
       }
@@ -325,16 +332,14 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
       }
       visible_layer_cnt++;
     }
-    if (canceled) {
+    if (cancelled_) {
       break;
     }
-    processed_layer_cnt++;
-    if (dialog != nullptr) {
-      dialog->setValue(100 * processed_layer_cnt / layers.count());
-      QCoreApplication::processEvents();
-    }
+    total_repeat_times_ = processed_repeat_times_ = 1;
+    onProgressChanged(0, true);
+    processed_layer_cnt_++;
   }
-  if (canceled) {
+  if (cancelled_) {
     return false;
   }
 
@@ -413,7 +418,7 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
     }
     gen_->end_task_script_block();
   }
-  if (canceled) {
+  if (cancelled_) {
     return false;
   }
 
@@ -622,21 +627,30 @@ void ToolpathExporterFcode::convertLaserLayer() {
   preview_painter_ = std::make_unique<QPainter>(&preview_bitmap_);
   preview_bitmap_.fill(Qt::white);
   bitmap_dirty_area_ = QRectF();
+  element_cnt_[0] = 0, element_cnt_[1] = 0;
   // First pass: Generate path list and bitmap list and draw filled path by layer_painter_
   for (auto& shape : current_layer_->children()) {
     convertShape(shape);
   }
   // Reverse order and handle closed path
   sortPolygons();
+  if (this->cancelled_) return;
+  onProgressChanged(0.05, true);
+  total_element_cnt_ = element_cnt_[0] + element_cnt_[1] + layer_bitmaps_.size();
+
   // Part 1: Generate path fcode
   outputLayerPathFcode();
+  if (this->cancelled_) return;
+  onProgressChanged(0.05 + 0.95 * element_cnt_[0] / total_element_cnt_, true);
 
-  is_handling_bitmap_ = true;
   // Part 2: Generate filled path fcode
   outputBitmapFcode();
+  if (this->cancelled_) return;
+  onProgressChanged(0.05 + 0.95 * (element_cnt_[0] + element_cnt_[1]) / total_element_cnt_, true);
 
   // Second pass
   // Part 3: Generate bitmap fcode
+  is_handling_bitmap_ = true;
   for (auto& shape : layer_bitmaps_) {
     // Note: Bitmap list is already reversed for first-depth shapes
     // When converting group, reverse order of children and ignore paths
@@ -647,6 +661,9 @@ void ToolpathExporterFcode::convertLaserLayer() {
 }
 
 void ToolpathExporterFcode::convertPrintingLayer() {
+  // Overwrite repeat, count progress as a whole
+  processed_repeat_times_ = 0, total_repeat_times_ = 1;
+
   gen_->enter_printer_mode();
 
   float black_ratio = 1;
@@ -675,6 +692,7 @@ void ToolpathExporterFcode::convertPrintingLayer() {
   for (auto& shape : current_layer_->children()) {
     convertShape(shape);
   }
+  if (this->cancelled_) return;
 
   // Generate bitmap
   outputLayerPrintingFcode(halftone_multiplier);
@@ -803,6 +821,7 @@ void ToolpathExporterFcode::convertPath(const PathShape* path) {
       preview_painter_->setBrush(Qt::NoBrush);
     }
     bitmap_dirty_area_ = bitmap_dirty_area_.united(path_bounding_rect);
+    element_cnt_[1]++;
   } else if (is_printing_layer_) {
     // Note: This is for dev convinience
     // Path in BVG input should already been converted to image
@@ -822,6 +841,7 @@ void ToolpathExporterFcode::convertPath(const PathShape* path) {
     if (is_v2_) {
       preview_painter_->drawPath(transformed_path * getPreviewTransform());
     }
+    element_cnt_[0]++;
     polygons_mutex_.unlock();
   }
 }
@@ -1038,6 +1058,7 @@ void ToolpathExporterFcode::outputBitmapFcode(bool pwm_engraving, int downsample
         step = qMax(config_.fg_pwm_limit - padding_px_ * 2, 100);
       }
       for (int left = bbox.left(); left <= bbox.right(); left += step) {
+        bitmap_progress_unit_ = 0.95 * element_cnt_[1] / total_element_cnt_ / bboxes.size() / qCeil(bbox.width() / step) / bbox.height();
         int right = qMin(left + step, bbox.left() + bbox.width()) - 1;
         QRect sliced_box = QRect(bbox);
         sliced_box.setLeft(left);
@@ -1089,6 +1110,10 @@ bool ToolpathExporterFcode::rasterBitmap(const QImage& layer_image,
     if (has_move && enable_bidirection_) {
       reverse_raster_dir = !reverse_raster_dir;
     }
+    if (cancelled_) {
+      return false;
+    }
+    onProgressChanged(bitmap_progress_unit_, false);
 
     y += y_step;
   }
@@ -1427,14 +1452,19 @@ void ToolpathExporterFcode::outputLayerPrintingFcode(float halftone_multiplier) 
   }
 
   // Slice boxes for each contour
+  int total_box = 0;
   QVector<QRect> bboxes = getBoundingBoxes(&layer_image, padding_px_, printing_slice_height);
   QList<QList<QList<int>>> sliced_boxes = {};
   for (auto bbox : bboxes) {
     sliceBox(&sliced_boxes, bbox, multipass);
+    total_box += sliced_boxes.constLast().size();
   }
+  if (this->cancelled_) return;
+  onProgressChanged(0.05, true);
 
   // Generate fcode
   int repeat = current_layer_->repeat();
+  float progress_unit = 0.9 / total_box / repeat;
   for (auto& boxes : sliced_boxes) {
     bool reverse_raster_dir = false;
     for (auto box = boxes.cbegin(); box != boxes.cend(); box++) {
@@ -1527,9 +1557,13 @@ void ToolpathExporterFcode::outputLayerPrintingFcode(float halftone_multiplier) 
         if (enable_bidirection_) {
           reverse_raster_dir = !reverse_raster_dir;
         }
+        if (this->cancelled_) return;
+        onProgressChanged(progress_unit, false);
       }
     }
   }
+  if (this->cancelled_) return;
+  onProgressChanged(0.95, true);
 }
 
 QByteArray ToolpathExporterFcode::generateNozzleSettingPayload(
@@ -2037,4 +2071,28 @@ QVector<QRect> ToolpathExporterFcode::getBoundingBoxes(QImage* src,
   qInfo() << "Final contour count:" << contours.size() << "after" << safeCount << "iterations";
 
   return res;
+}
+
+void ToolpathExporterFcode::handleCancel() {
+  this->cancelled_ = true;
+}
+
+/**
+ * Update progress and emit signal if necessary
+ * Also check if the process is cancelled
+ */
+void ToolpathExporterFcode::onProgressChanged(double value, bool absolute) {
+  current_progress_ = absolute ? value : current_progress_ + value;
+  // 5% for pre-task, 5% for printing test and post-task
+  int new_progress = 5 + 90 * (processed_layer_cnt_ + (processed_repeat_times_ + current_progress_) / total_repeat_times_) / total_layer_cnt_;
+  if (new_progress > progress_) {
+    progress_ = new_progress;
+    if (dialog_ != nullptr) {
+      dialog_->setValue(progress_);
+    } else {
+      Q_EMIT progressChanged(progress_);
+    }
+  }
+  // Always call processEvents to receive the cancellation signal quickly
+  QCoreApplication::processEvents();
 }

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -152,6 +152,12 @@ class ToolpathExporterFcode : public QObject {
   bool convertStack(const QList<LayerPtr>& layers,
                     QProgressDialog* dialog = nullptr);
 
+Q_SIGNALS:
+  void progressChanged(int value);
+
+public Q_SLOTS:
+  void handleCancel();
+
  private:
   void parseParam(const QJsonObject* paramPtr) {
     QJsonObject param = *paramPtr;
@@ -493,6 +499,8 @@ class ToolpathExporterFcode : public QObject {
                bool force_y,
                bool is_travel);
 
+  void onProgressChanged(double value, bool absolute);
+
   // white = 255 = no emit, black = 0 = emit
   const int white_val = 255;
   // for pwm, val < pwm_threshold = emit
@@ -598,4 +606,16 @@ class ToolpathExporterFcode : public QObject {
   float max_x_ = std::nanf("");
   float min_y_ = std::nanf("");
   float max_y_ = std::nanf("");
+  // Task progress
+  QProgressDialog* dialog_ = nullptr;
+  bool cancelled_ = false;
+  int total_layer_cnt_ = 1;
+  int processed_layer_cnt_ = 0;
+  int total_repeat_times_ = 1;
+  int processed_repeat_times_ = 0;
+  int element_cnt_[2] = {0, 0}; // 0 Path, 1 Filled Path (Bitmap)
+  int total_element_cnt_ = 0;
+  double bitmap_progress_unit_ = 0;
+  double current_progress_ = 0; // progress within current repeat
+  int progress_ = 0;
 };

--- a/src/toolpath_exporter/toolpath-exporter.cpp
+++ b/src/toolpath_exporter/toolpath-exporter.cpp
@@ -28,6 +28,7 @@ ToolpathExporter::ToolpathExporter(BaseGenerator *generator, qreal dpmm, double 
 bool ToolpathExporter::convertStack(const QList<LayerPtr> &layers, bool is_high_speed, bool start_with_home) {
   qInfo() << "[Export] Start converting stack with layers" << layers.count();
   is_high_speed_ = is_high_speed;
+  progress_ = 0;
   QElapsedTimer t;
   t.start();
   // Initial Setup
@@ -62,16 +63,17 @@ bool ToolpathExporter::convertStack(const QList<LayerPtr> &layers, bool is_high_
     layer_bitmaps_[i].fill(Qt::white);
     bitmap_dirty_areas_.append(QRectF());
   }
-  int processed_layer_cnt = 0;
+  processed_layer_cnt_ = 0;
+  total_layer_cnt_ = layers.size();
   for (auto layer_rit = layers.crbegin(); layer_rit != layers.crend(); layer_rit++) {
     if ((*layer_rit)->isVisible()) {
       qInfo() << "[Export] Output layer: " << (*layer_rit)->name();
-      int repeat = (*layer_rit)->repeat();
+      total_repeat_times_ = (*layer_rit)->repeat();
       float focus = (*layer_rit)->focus();
       float focus_step = (*layer_rit)->focusStep();
       float total_move = 0;
-      for (int i = 0; i < repeat; i++) {
-        if (i == 0) {
+      for (processed_repeat_times_ = 0; processed_repeat_times_ < total_repeat_times_; processed_repeat_times_++) {
+        if (processed_repeat_times_ == 0) {
           if (focus > 0) {
             // Make sure cmd list is opened
             gen_->turnOnLaser();
@@ -93,9 +95,9 @@ bool ToolpathExporter::convertStack(const QList<LayerPtr> &layers, bool is_high_
     if (this->cancelled_) {
       break;
     }
-    processed_layer_cnt++;
-    Q_EMIT progressChanged(100 * processed_layer_cnt / layers.count());
-    QCoreApplication::processEvents();
+    total_repeat_times_ = processed_repeat_times_ = 1;
+    onProgressChanged(0, true);
+    processed_layer_cnt_++;
   }
   
   if (this->cancelled_) {
@@ -132,6 +134,9 @@ void ToolpathExporter::convertLayer(const LayerPtr &layer) {
   layer_filled_polygons_.clear();
   polygons_mutex_.unlock();
   with_image_ = false;
+  for (int i = 0; i < 5; i++) {
+    element_cnt_[i] = 0;
+  }
   //layer_painter_->fillRect(bitmap_dirty_area_, Qt::white);
   for (int i = BitmapHandlerType::NormalMode; i < BitmapHandlerType::DepthMode; ++i) {
     bitmap_dirty_areas_[i] = QRectF();
@@ -152,6 +157,7 @@ void ToolpathExporter::convertLayer(const LayerPtr &layer) {
     convertShape(shape);
   }
   sortPolygons();
+  onProgressChanged(0.05, true);
   outputLayerGcode();
 }
 
@@ -191,7 +197,14 @@ void ToolpathExporter::convertGroup(const GroupShape *group) {
  */
 void ToolpathExporter::convertBitmap(const BitmapShape *bmp) {
   QTransform transform = bmp->transform() * global_transform_;
-  BitmapHandlerType type = bmp->gradient() ? BitmapHandlerType::GradientMode : BitmapHandlerType::NormalMode;
+  BitmapHandlerType type;
+  if (bmp->gradient()) {
+    type = BitmapHandlerType::GradientMode;
+    element_cnt_[1]++;
+  } else {
+    type = BitmapHandlerType::NormalMode;
+    element_cnt_[0]++;
+  }
   layer_painter_ = std::make_unique<QPainter>(&layer_bitmaps_[type]);
   layer_painter_->save();
   layer_painter_->setTransform(transform, false);
@@ -326,10 +339,27 @@ void ToolpathExporter::sortPolygons() {
  * 
  */
 void ToolpathExporter::outputLayerGcode() {
+  element_cnt_[3] = layer_filled_polygons_.size();
+  element_cnt_[4] = layer_polygons_.size();
+  total_element_cnt_ = 0;
+  for (int i = 0; i < 5; i++) {
+    total_element_cnt_ += element_cnt_[i];
+  }
+
   outputLayerBitmapGcode(BitmapHandlerType::NormalMode);
+  if (this->cancelled_) return;
+  onProgressChanged(0.05 + 0.95 * element_cnt_[0] / total_element_cnt_, true);
+
   outputLayerBitmapGcode(BitmapHandlerType::GradientMode);
+  if (this->cancelled_) return;
+  onProgressChanged(0.05 + 0.95 * (element_cnt_[0] + element_cnt_[1]) / total_element_cnt_, true);
+
   outputLayerFillGcode();
+  if (this->cancelled_) return;
+  onProgressChanged(0.05 + 0.95 * (total_element_cnt_ - element_cnt_[4]) / total_element_cnt_, true);
+
   outputLayerPathGcode();
+  onProgressChanged(1, true);
 }
 
 /**
@@ -378,7 +408,13 @@ void ToolpathExporter::outputLayerFillGcode() {
     return;
   }
 
+  // Report progress every 1 percent
+  float progress_unit = 0.0095 * element_cnt_[3] / total_element_cnt_;
+  int progress_batch = (hatch_count * diagonal * 1.5 / fill_interval) / 100 + 1;
+  int cnt = -1;
+
   for (int hatch = 0; hatch < hatch_count; hatch++) {
+    if (this->cancelled_) return;
     // Convert angle to radians
     double angleRad = qDegreesToRadians(fill_angle);
 
@@ -427,6 +463,12 @@ void ToolpathExporter::outputLayerFillGcode() {
     bool reverse = false;
     // Scan across the path
     for (double offset = -diagonal / 2; offset <= diagonal; offset += fill_interval) {
+      if (this->cancelled_) {
+        return;
+      }
+      if (++cnt % progress_batch == 0) {
+        onProgressChanged(progress_unit, false);
+      }
       // Calculate line start and end points
       QPointF lineStart = start + perpendicular * offset - direction * diagonal / 2;
       QPointF lineEnd = lineStart + direction * diagonal;
@@ -726,9 +768,11 @@ void ToolpathExporter::outputLayerBitmapGcode(BitmapHandlerType type) {
       if (is_high_speed_) {
         rasterBitmapHighSpeed(layer_image, bbox, ScanDirectionMode::kBidirectionMode, padding_mm);
       } else {
+        std::swap(element_cnt_[0], element_cnt_[1]);
         int count = 0;
         rasterBitmap(layer_image, bbox, ScanDirectionMode::kBidirectionMode, padding_mm, &count);
         gen_->addComment(QString("DOT%1").arg(count));
+        std::swap(element_cnt_[0], element_cnt_[1]);
       }
       gen_->setDottingTime(0);
       break;
@@ -771,8 +815,18 @@ bool ToolpathExporter::rasterBitmap(const QImage &layer_image,
   qInfo() << "bbox: " << bbox;
   qInfo() << "# of raster line: " << raster_lines.size();
 
+  float progress_unit = 0.0095 * element_cnt_[0] / total_element_cnt_;
+  int progress_batch = raster_lines.size() / 100;
+  int cnt = -1;
+
   // 2-2. iterate
   for (const auto &raster_line: raster_lines) {
+    if (this->cancelled_) {
+      return false;
+    }
+    if (++cnt % progress_batch == 0) {
+      onProgressChanged(progress_unit, false);
+    }
     // Initialize
     if (raster_line.isNull()) {
       continue;
@@ -1075,8 +1129,18 @@ bool ToolpathExporter::rasterBitmapHighSpeed(const QImage &layer_image,
   qInfo() << "bbox: " << bbox;
   qInfo() << "# of raster line: " << raster_lines.size();
 
+  float progress_unit = 0.0095 * element_cnt_[1] / total_element_cnt_;
+  int progress_batch = raster_lines.size() / 100;
+  int cnt = -1;
+
   // 2-2. iterate
   for (const auto &raster_line: raster_lines) {
+    if (this->cancelled_) {
+      return false;
+    }
+    if (++cnt % progress_batch == 0) {
+      onProgressChanged(progress_unit, false);
+    }
     // Initialize
     if (raster_line.isNull()) {
       continue;
@@ -1245,4 +1309,19 @@ inline void ToolpathExporter::moveTo(const QPointF& dest, double speed, double p
 
 void ToolpathExporter::handleCancel() {
   this->cancelled_ = true;
+}
+
+/**
+ * Update progress and emit signal if necessary
+ * Also check if the process is cancelled
+ */
+void ToolpathExporter::onProgressChanged(double value, bool absolute) {
+  current_progress_ = absolute ? value : current_progress_ + value;
+  int new_progress = 100 * (processed_layer_cnt_ + (processed_repeat_times_ + current_progress_) / total_repeat_times_) / total_layer_cnt_;
+  if (new_progress > progress_) {
+    progress_ = new_progress;
+    Q_EMIT progressChanged(progress_);
+  }
+  // Always call processEvents to receive the cancellation signal quickly
+  QCoreApplication::processEvents();
 }

--- a/src/toolpath_exporter/toolpath-exporter.h
+++ b/src/toolpath_exporter/toolpath-exporter.h
@@ -90,6 +90,8 @@ private:
 
   QImage imageBinarize(QImage src, int threshold);
 
+  void onProgressChanged(double value, bool absolute);
+
   QTransform global_transform_;
   LayerPtr current_layer_;
   std::unique_ptr<QPainter> layer_painter_;
@@ -122,4 +124,13 @@ private:
   bool with_image_ = false;
   bool cancelled_ = false;
   PathSort sort_rule_;
+  // ===== Calculate current progress percentage ======
+  int total_layer_cnt_ = 1;
+  int processed_layer_cnt_ = 0;
+  int total_repeat_times_ = 1;
+  int processed_repeat_times_ = 0;
+  int element_cnt_[5] = {0, 0, 0, 0, 0}; // 0 Normal Bitmap, 1 Gradient Bitmap, 2 Depth Bitmap, 3 Filled Path, 4 Unfilled Path
+  int total_element_cnt_ = 0;
+  double current_progress_ = 0; // progress within current repeat
+  int progress_ = 0;
 };


### PR DESCRIPTION
Move `loadSVG` and `convert` to a worker thread
Report progress and handling interrupt signal during `convertStack` (Promark & B-series) and `calcTotalTime` (Promark only)
- Interrupt task if corresponding socket is closed
- Reject task if another task is running by mutex (to keep m_canvas and other variables safe)
- Check socket still alive

Split large fcode data
Add binary msg handler
