### PR TITLE
Fix large path element being truncated

### DIFF
--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -29,6 +29,8 @@ SwiftrayServer::SwiftrayServer(quint16 port, QObject* parent)
     qCritical() << "Failed to start Swiftray Server on port" << port;
   }
   setupWorker();
+  // Set env to avoid Path truncated in parsePathDataFast
+  qputenv("QT_SVG_ASSUME_TRUSTED_SOURCE", "");
 }
 
 Machine* SwiftrayServer::getMachine() {


### PR DESCRIPTION
Set QT_SVG_ASSUME_TRUSTED_SOURCE to disable length limit when parsing