### PR TITLE
Restrict list time

### DIFF
--- a/src/periph/motion_controller/bsl_motion_controller.cpp
+++ b/src/periph/motion_controller/bsl_motion_controller.cpp
@@ -13,6 +13,7 @@
 #include <QtCore/qcoreapplication.h>
 
 #define MAX_BUFFER_LIST_SIZE 10000
+#define MAX_BUFFER_LIST_TIME 30000
 
 int lcs_error_count = 0;
 uint32_t pos;
@@ -509,8 +510,8 @@ void BSLMotionController::handleGcode(const QString &gcode) {
     }
 
     this->buffer_size_++;
-    
-    if (this->buffer_size_ >= MAX_BUFFER_LIST_SIZE) {
+
+    if (this->buffer_size_ >= MAX_BUFFER_LIST_SIZE || estimated_time_ >= MAX_BUFFER_LIST_TIME) {
         should_swap = true;
     }
 

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -209,7 +209,7 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
         gen_->write_string("TASK", 4);
         // Write transition script
         gen_->start_task_script_block("TRAN", NULL);
-        if (config_.support_modules) {
+        if (!is_gcode_ && config_.support_modules) {
           if (is_rotary_task_ && config_.enable_rotary_z_move) {
             moveZ(1);
           }


### PR DESCRIPTION
1. Max 30 seconds for each list
目前斷線時會強制等待當前的 list 做完再開始重連，限制 List 時長以避免卡太久
TODO：
邊等邊檢查 user 是否主動觸發 stop
斷線後立刻更新狀態 Reconnecting、確定斷線後狀態改為 Aborted


2. Skip transition script in Ador path preview