### PR TITLE
Fix QT_SVG_ASSUME_TRUSTED_SOURCE not set in Windows

### DIFF
--- a/src/server/swiftray-server.cpp
+++ b/src/server/swiftray-server.cpp
@@ -30,7 +30,7 @@ SwiftrayServer::SwiftrayServer(quint16 port, QObject* parent)
   }
   setupWorker();
   // Set env to avoid Path truncated in parsePathDataFast
-  qputenv("QT_SVG_ASSUME_TRUSTED_SOURCE", "");
+  qputenv("QT_SVG_ASSUME_TRUSTED_SOURCE", "1");
 }
 
 Machine* SwiftrayServer::getMachine() {


### PR DESCRIPTION
https://doc.qt.io/qt-6/qtenvironmentvariables-qtcore-proxy.html#qputenv
> Calling qputenv with an empty value removes the environment variable on Windows, and makes it set (but empty) on Unix