### PR TITLE
Ignore error if current list is not valid

### DIFF
--- a/src/periph/motion_controller/bsl_list_manager.cpp
+++ b/src/periph/motion_controller/bsl_list_manager.cpp
@@ -193,7 +193,7 @@ int BSLListManager::doApiCall(ListApiCall call) {
   }
 
   if (error != LCS_RES_NO_ERROR) {
-    if (controller_->is_running_laser_) {
+    if (controller_->is_running_laser_ && backup_list_no_ > 0) {
       QString apiName = getApiName(call.type);
       QString argStr = formatArgs(call.args, call.type);
       qInfo() << "[LCS API Result]" << apiName << "(" << argStr << ") failed with error:" << controller_->getErrorString(error);


### PR DESCRIPTION
Ignore api errors during `stop()` process
( after `lcs_set_end_of_list();` before `this->is_running_laser_ = false;` )