### PR TITLE
Update toolpath exporters to handle clip, loop compensate and sort for path

### DIFF
--- a/src/server/worker.cpp
+++ b/src/server/worker.cpp
@@ -161,7 +161,7 @@ bool Worker::handleAction(QWebSocket* socket,
         exporter.setSortRule(PathSort::NestedSort);
         exporter.setWorkAreaSize(QRectF(0, 0, server_->m_canvas->document().width() / 10, server_->m_canvas->document().height() / 10));
         if (type == "contour") exporter.handleContour();
-        if (params_obj.contains("mask")) exporter.setShouldClipWorkarea(true);
+        else exporter.setLoopCompensation(params_obj["loop_compensation"].toDouble());
 
         current_task = "Generating Task Code...";
         onProgress(0);

--- a/src/toolpath_exporter/generators/fcode-generator.h
+++ b/src/toolpath_exporter/generators/fcode-generator.h
@@ -805,19 +805,19 @@ class FCodeGeneratorG : public FCodeGenerator {
       str_stream << " F" << feedrate;
     }
     if (flags & FCodeGenerator::move_flag_X) {
-      str_stream << " X" << x;
+      str_stream << " X" << std::round(x * 1000) / 1000;
     }
     if (flags & FCodeGenerator::move_flag_Y) {
-      str_stream << " Y" << y;
+      str_stream << " Y" << std::round(y * 1000) / 1000;
     }
     if (flags & FCodeGenerator::move_flag_Z) {
-      str_stream << " Z" << z;
+      str_stream << " Z" << std::round(z * 1000) / 1000;
     }
     if (flags & FCodeGenerator::move_flag_A) {
-      str_stream << " Y" << a;
+      str_stream << " Y" << std::round(a * 1000) / 1000;
     }
     if (flags & FCodeGenerator::move_flag_S) {
-      str_stream << " S" << s;
+      str_stream << " S" << std::round(s * 1000) / 1000;
     }
     str_stream << "\n";
   }

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -35,30 +35,6 @@ QString convertUnicode(const QString s) {
   return result;
 }
 
-bool isIntersectWithCenter(int position1, int position2) {
-  // 0 1 2
-  // 3 4 5
-  // 6 7 8
-  if (position1 == 4 || position2 == 4) {
-    return true;
-  } else if (position1 == position2) {
-    return false;
-  } else if (position1 == 1 || position1 == 7) {
-    return abs(position1 - position2) != 1;
-  } else if (position1 == 3 || position1 == 5) {
-    return abs(position1 - position2) != 3;
-  } else if (position1 == 0) {
-    return position2 == 5 || position2 == 7 || position2 == 8;
-  } else if (position1 == 2) {
-    return position2 == 3 || position2 == 6 || position2 == 7;
-  } else if (position1 == 6) {
-    return position2 == 1 || position2 == 2 || position2 == 5;
-  } else {
-    // position1 == 8
-    return position2 == 0 || position2 == 1 || position2 == 3;
-  }
-}
-
 bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
                                          QProgressDialog* dialog) {
   // Step 1. Initialize
@@ -608,10 +584,7 @@ void ToolpathExporterFcode::updateClip() {
   float clip_bottom = mm2px(work_area_mm_.height() - layer_clip[2]) - 1;
   float clip_left = mm2px(layer_clip[3], true);
   clip_area_ = QRect(QPoint(clip_left, clip_top), QPoint(clip_right, clip_bottom));
-  border_lines_[0] = QLineF(clip_left, clip_top, clip_right, clip_top);
-  border_lines_[1] = QLineF(clip_right, clip_top, clip_right, clip_bottom);
-  border_lines_[2] = QLineF(clip_left, clip_bottom, clip_right, clip_bottom);
-  border_lines_[3] = QLineF(clip_left, clip_top, clip_left, clip_bottom);
+  path_utils_.setClipRect(clip_top, clip_right, clip_bottom, clip_left);
 }
 
 void ToolpathExporterFcode::convertLaserLayer() {
@@ -631,8 +604,7 @@ void ToolpathExporterFcode::convertLaserLayer() {
   for (auto& shape : current_layer_->children()) {
     convertShape(shape);
   }
-  // Reverse order and handle closed path
-  sortPolygons();
+  path_utils_.sortAndPreprocessPolygons(layer_polygons_);
   if (this->cancelled_) return;
   onProgressChanged(0.05, true);
   total_element_cnt_ = element_cnt_[0] + element_cnt_[1] + layer_bitmaps_.size();
@@ -844,29 +816,6 @@ void ToolpathExporterFcode::convertPath(const PathShape* path) {
   }
 }
 
-// Complexity: O(n^2)
-void ToolpathExporterFcode::sortPolygons() {
-  QList<QPolygonF> sort_result;
-  QVector2D unit(1 / dpmm_x(), 1 / dpmm_y());
-  for (const auto& polygon : layer_polygons_) {
-    // Insert from the beginning (reverse order)
-    int insert_idx = 0;
-    float d = (QVector2D(polygon.first() - polygon.last()) * unit).length();
-    if (d <= config_.loop_compensation) {
-      // Handle closed path
-      for (int idx = sort_result.size() - 1; idx >= 0; idx--) {
-        if (polygon.boundingRect().contains(sort_result[idx].boundingRect())) {
-          // Move current polygon after smaller one
-          insert_idx = idx + 1;
-          break;
-        }
-      }
-    }
-    sort_result.insert(insert_idx, polygon);
-  }
-  layer_polygons_ = sort_result;
-}
-
 void ToolpathExporterFcode::outputLayerPathFcode() {
   bool should_set_acc = !config_.path_acc.isEmpty();
   polygons_mutex_.lock();
@@ -883,49 +832,11 @@ void ToolpathExporterFcode::outputLayerPathFcode() {
       );
     }
     setTravelSpeed(config_.path_travel_speed);
-    int last_position = getPointPosition(poly.first());
-    if (last_position == 4) {
-      handlePathWalk(poly.first(), false);
-    }
-    QPointF* last_point = nullptr;
+    handlePathWalk(poly.first(), false);
     for (QPointF& point : poly) {
-      int position = getPointPosition(point);
-      QPointF intersection;
-      if (position == 4) {
-        if (last_position != 4) {
-          // From outside to inside
-          // Handle additional intersection point first and start laser
-          QLineF current_line(*last_point, point);
-          getIntersectPoint(current_line, last_position, &intersection);
-          handlePathWalk(intersection, false);
-          handlePathWalk(intersection, true);
-        }
-        // Normal walk
-        handlePathWalk(point, true);
-      } else if (last_position == 4) {
-        // From inside to outside
-        // Clip current point and stop laser
-        QLineF current_line(*last_point, point);
-        getIntersectPoint(current_line, position, &intersection);
-        handlePathWalk(intersection, true);
-        handlePathWalk(intersection, false);
-      } else if (isIntersectWithCenter(last_position, position)) {
-        // From one side to another side
-        // Need to handle two intersection points
-        QLineF current_line(*last_point, point);
-        getIntersectPoint(current_line, last_position, &intersection);
-        handlePathWalk(intersection, false);
-        handlePathWalk(intersection, true);
-        getIntersectPoint(current_line, position, &intersection);
-        handlePathWalk(intersection, true);
-        handlePathWalk(intersection, false);
-      }
-      last_point = &point;
-      last_position = position;
+      handlePathWalk(point, true);
     }
-    if (last_position == 4) {
-      handlePathWalk(*last_point, false);
-    }
+    handlePathWalk(poly.last(), false);
     setTravelSpeed(config_.travel_speed);
     // Reset path_acc
     if (should_set_acc) {
@@ -934,67 +845,6 @@ void ToolpathExporterFcode::outputLayerPathFcode() {
     }
   }
   polygons_mutex_.unlock();
-}
-
-int ToolpathExporterFcode::getPointPosition(QPointF point) {
-  int position = 4;
-  if (point.x() < clip_area_.left()) {
-    position -= 1;
-  } else if (point.x() > clip_area_.right()) {
-    position += 1;
-  }
-  if (point.y() < clip_area_.top()) {
-    position -= 3;
-  } else if (point.y() > clip_area_.bottom()) {
-    position += 3;
-  }
-  return position;
-}
-
-void ToolpathExporterFcode::getIntersectPoint(QLineF line,
-                                              int position,
-                                              QPointF* point) {
-  QLineF::IntersectionType type;
-  switch (position) {
-    case 0:
-      type = line.intersects(border_lines_[0], point);
-      if (type != QLineF::BoundedIntersection) {
-        line.intersects(border_lines_[3], point);
-      }
-      break;
-    case 1:
-      line.intersects(border_lines_[0], point);
-      break;
-    case 2:
-      type = line.intersects(border_lines_[0], point);
-      if (type != QLineF::BoundedIntersection) {
-        line.intersects(border_lines_[1], point);
-      }
-      break;
-    case 3:
-      line.intersects(border_lines_[3], point);
-      break;
-    case 5:
-      line.intersects(border_lines_[1], point);
-      break;
-    case 6:
-      type = line.intersects(border_lines_[2], point);
-      if (type != QLineF::BoundedIntersection) {
-        line.intersects(border_lines_[3], point);
-      }
-      break;
-    case 7:
-      line.intersects(border_lines_[2], point);
-      break;
-    case 8:
-      type = line.intersects(border_lines_[2], point);
-      if (type != QLineF::BoundedIntersection) {
-        line.intersects(border_lines_[1], point);
-      }
-      break;
-    default:
-      break;
-  }
 }
 
 void ToolpathExporterFcode::handlePathWalk(QPointF point, bool should_emit) {

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -22,19 +22,6 @@ float positiveMod(float n, float m) {
   return val;
 }
 
-float getAngle(QVector2D v1, QVector2D v2) {
-  int direction_sign = v1.x() * v2.y() - v1.y() * v2.x() < 0 ? -1 : 1;
-  float cos_val = QVector2D::dotProduct(v1, v2) / (v1.length() * v2.length());
-  return direction_sign * acos(qMax(qMin(cos_val, float(1.0)), float(-1.0)));
-}
-
-QPointF getBladeCompensation(QPointF position,
-                             QVector2D vector,
-                             float radius = 0.6) {
-  float r = radius / vector.length();
-  return (QVector2D(position) + vector * r).toPointF();
-}
-
 QString convertUnicode(const QString s) {
   QString result;
   for (int i = 0; i < s.size(); i++) {
@@ -141,19 +128,6 @@ bool ToolpathExporterFcode::convertStack(const QList<LayerPtr>& layers,
   }
 
   gen_->set_time_est_acc(config_.padding_acc);
-
-  // precut
-  if (config_.enable_precut) {
-    current_vector_ = QVector2D(1, 0);
-    QPointF precut_dest_xy = (QVector2D(config_.precut_at) + current_vector_).toPointF();
-    travel(config_.precut_at);
-    gen_->set_toolhead_pwm(100);
-    QPointF new_dest = getBladeCompensation(precut_dest_xy, current_vector_,
-                                            config_.blade_radius);
-    moveto(800, new_dest.x(), new_dest.y());
-    current_xy_ = precut_dest_xy;
-    gen_->set_toolhead_pwm(0, true);
-  }
 
   // End of pre-task script
   if (is_v2_) {
@@ -1025,40 +999,11 @@ void ToolpathExporterFcode::getIntersectPoint(QLineF line,
 
 void ToolpathExporterFcode::handlePathWalk(QPointF point, bool should_emit) {
   QPointF next_point_mm = getPointInMM(point);
-  if (with_blade_) {
-    QVector2D target_vector(next_point_mm - current_xy_);
-    if (!target_vector.isNull()) {
-      if (!current_vector_.isNull()) {
-        float angle = getAngle(current_vector_, target_vector);
-        while (abs(angle) > 0.01) {
-          int dir = angle > 0 ? 1 : -1;
-          float rotate_angle = dir * qMin(abs(angle), float(0.1));
-          QVector2D rotated_vector(current_vector_.x() * cos(rotate_angle) -
-                                       current_vector_.y() * sin(rotate_angle),
-                                   current_vector_.x() * sin(rotate_angle) +
-                                       current_vector_.y() * cos(rotate_angle));
-          rotated_vector.normalize();
-          rotated_vector *= config_.blade_radius;
-          moveto(300, current_xy_.x() + rotated_vector.x(),
-                 current_xy_.y() + rotated_vector.y());
-          angle = getAngle(rotated_vector, target_vector);
-        }
-      }
-      if (gen_->current_pwm != 0) {
-        current_vector_ = target_vector;
-      }
-    }
-  }
-  if (with_blade_ && !current_vector_.isNull()) {
-    next_point_mm = getBladeCompensation(next_point_mm, current_vector_,
-                                         config_.blade_radius);
-    moveto(path_speed_, next_point_mm.x(), next_point_mm.y());
-  } else if (should_emit) {
+  if (should_emit) {
     moveto(path_speed_, next_point_mm.x(), next_point_mm.y());
   } else {
     travel(next_point_mm);
   }
-  current_xy_ = next_point_mm;
   float target_power = should_emit ? 100 : 0;
   if (gen_->current_pwm != target_power) {
     gen_->set_toolhead_pwm(target_power, true);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -73,13 +73,11 @@ struct Config {
   float min_printing_padding = NAN;
   float spinning_axis_coord = -1;
   float z_offset = 0;
-  float blade_radius = 0;
   float loop_compensation = 0;
   float workarea_clip[4] = {0, 0, 0, 0}; // inward offset; top, right, bottom, left
   float z_premove_x = 0;
   float z_premove_y = 0;
   float z_premove_z = 0;
-  QPointF precut_at;
   QPointF diode_offset;
   QPointF job_origin;
   QMap<int, QPointF> module_offsets;
@@ -95,7 +93,6 @@ struct Config {
   float dpmm_preview;
   // fountion on/off
   bool enable_pwm = true;
-  bool enable_precut = false;
   bool enable_diode = false;
   bool enable_autofocus = false;
   bool enable_custom_backlash = false;
@@ -293,15 +290,6 @@ public Q_SLOTS:
     config_.min_engraving_padding = param["mep"].toDouble(NAN);
     config_.min_printing_padding = param["mpp"].toDouble(NAN);
     config_.z_offset = param["z_offset"].toDouble(0);
-    config_.blade_radius = param["blade"].toDouble();
-    if (config_.blade_radius > 0) {
-      with_blade_ = true;
-      if (param.contains("precut")) {
-        config_.enable_precut = true;
-        config_.precut_at = QPointF(param["precut"].toArray()[0].toDouble(),
-                                    param["precut"].toArray()[1].toDouble());
-      }
-    }
     config_.loop_compensation = param["loop_compensation"].toDouble() / canvas_mm_ratio;
     config_.printing_top_padding = param["ptp"].toInt(10);
     config_.printing_bot_padding = param["pbp"].toInt(10);
@@ -595,7 +583,6 @@ public Q_SLOTS:
   bool is_v2_ = false;
   bool is_rotary_task_ = false;
   bool is_3d_task_ = false;
-  bool with_blade_ = false;
   bool with_custom_origin_ = false;
 
   QSizeF work_area_mm_;
@@ -641,9 +628,6 @@ public Q_SLOTS:
   float rotary_y_ratio_ = 1;  // force set to 1 in post script
   QTransform global_transform_;
   std::vector<void(ToolpathExporterFcode::*)(MoveArgs args, std::function<void(MoveArgs args)> callback)> moveto_pipeline_functions_;
-  // For blade: blade position: current_xy - blade_radius * (current_vector / |current_vector|)
-  QPointF current_xy_ = QPointF(0, 0); // mm position of control point (not blade)
-  QVector2D current_vector_ = QVector2D(0, 0); // vector of cutting movement
   // For 3d curve
   float curve_started_ = false;
   float cur_x_ = 0;

--- a/src/toolpath_exporter/toolpath-exporter-fcode.h
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.h
@@ -380,6 +380,10 @@ public Q_SLOTS:
       config_.print_modes[0] = 'R', config_.print_modes[1] = 'H';
     }
 
+    // Calculate length in y px
+    path_utils_.setLengthRatio(config_.dpmm_x / config_.dpmm_y, 1);
+    path_utils_.setLoopCompensation(config_.loop_compensation * config_.dpmm_y);
+
     transform_laser_ = QTransform::fromScale(config_.dpmm_x / canvas_mm_ratio,
                                              config_.dpmm_y / canvas_mm_ratio);
     transform_printing_ =
@@ -464,11 +468,7 @@ public Q_SLOTS:
   void convertBitmap(const BitmapShape* bmp);
   void convertPath(const PathShape* path);
 
-  void sortPolygons();
-
   void outputLayerPathFcode();
-  int getPointPosition(QPointF point);
-  void getIntersectPoint(QLineF line, int position, QPointF* point);
   void handlePathWalk(QPointF point, bool should_emit);
 
   void outputBitmapFcode(bool pwm_engraving = false);
@@ -584,6 +584,7 @@ public Q_SLOTS:
   bool is_rotary_task_ = false;
   bool is_3d_task_ = false;
   bool with_custom_origin_ = false;
+  PathUtils path_utils_;
 
   QSizeF work_area_mm_;
   QTransform transform_laser_;
@@ -613,7 +614,6 @@ public Q_SLOTS:
   QString layer_color_;
   QString submodule_color_ = "None";
   QRect clip_area_;         // px;
-  QLineF border_lines_[4];  // px; top, right, bottom, left
 
   // Updated during processing
   bool is_handling_main_work_ = false;

--- a/src/toolpath_exporter/toolpath-exporter.cpp
+++ b/src/toolpath_exporter/toolpath-exporter.cpp
@@ -10,9 +10,6 @@
 #include <cmath>
 #include <constants.h>
 
-static const int CLIP_FLAG_START = 0b01;
-static const int CLIP_FLAG_END = 0b10;
-
 // TODO: Fix ToolpathExporter for non-Promark machines
 ToolpathExporter::ToolpathExporter(BaseGenerator *generator, qreal dpmm, double travel_speed, QPointF end_point, PaddingType padding_type, QTransform move_translate, bool is_promark) noexcept :
  gen_(generator), dpmm_(dpmm), padding_type_(padding_type), travel_speed_(travel_speed), end_point_(end_point), is_promark_(is_promark)
@@ -375,6 +372,10 @@ void nestedSort(QList<QPolygonF> &array) {
 }
 
 void ToolpathExporter::sortPolygons() {
+  if (is_promark_) {
+    path_utils_.sortAndPreprocessPolygons(layer_polygons_);
+    return;
+  }
   switch (sort_rule_)
   {
   case MergeSort:
@@ -555,7 +556,7 @@ void ToolpathExporter::outputLayerFillGcode() {
 
       QPointF innerStart(lineStart);
       QPointF innerEnd(lineEnd);
-      if (clipWorkarea(&innerStart, &innerEnd, true) == -1) continue;
+      if (path_utils_.clipWorkarea(&innerStart, &innerEnd) == -1) continue;
 
       // Get intersections with path
       QList<QList<QPointF>> all_intersections;
@@ -694,25 +695,11 @@ void ToolpathExporter::outputLayerPathGcode() {
   for (auto &poly : layer_polygons_) {
     if (poly.empty()) continue;
 
-    int clip_res;
-    bool is_first = true;
-    QPointF last_point = poly.first();
-    QPointF next_point;
     QPointF next_point_mm;
 
+    moveTo(poly.first() / dpmm_, travel_speed_, 0, 0);
     for (QPointF &point : poly) {
-      next_point = point;
-      clip_res = clipWorkarea(&last_point, &next_point, false);
-      if (clip_res == -1) {
-        last_point = point;
-        continue;
-      }
-      if (is_first || (clip_res & CLIP_FLAG_START)) {
-        // Travel to start point or Clipped point(out -> in)
-        is_first = false;
-        moveTo(last_point / dpmm_, travel_speed_, 0, 0);
-      }
-      next_point_mm = next_point / dpmm_;
+      next_point_mm = point / dpmm_;
       // Divide a long line into small segments
       if (!is_promark_ && (next_point_mm - current_pos_mm_).manhattanLength() > 5) { // At most 5mm per segment
         int segments = std::max(2.0,
@@ -728,12 +715,8 @@ void ToolpathExporter::outputLayerPathGcode() {
       } else {
         moveTo(next_point_mm, layer_speed, layer_power, 0);
       }
-      if (clip_res & CLIP_FLAG_END) {
-        // Turn off laser at Clipped point(in -> out)
-        moveTo(next_point_mm, travel_speed_, 0, 0);
-      }
-      last_point = point;
     }
+    moveTo(poly.last() / dpmm_, travel_speed_, 0, 0);
 
     //gen_->turnOffLaser();
   }
@@ -1397,62 +1380,6 @@ bool ToolpathExporter::rasterBitmapDepthMode(ScanDirectionMode direction_mode,
   gen_->useAbsolutePositioning();
   gen_->turnOffLaser();
   return true;
-}
-
-int ToolpathExporter::clipWorkarea(QPointF* start, QPointF* end, bool force) {
-  int clip_result = 0;
-  if (!force && !should_clip_workarea_) {
-    return clip_result;
-  }
-  QLineF scanLine(*start, *end);
-  bool ok = false;
-  double x1 = start->x();
-  double y1 = start->y();
-  bool is_p1_outside = (x1 < 0 || x1 > canvas_width_ || y1 < 0 || y1 > canvas_height_);
-  if (is_p1_outside) {
-    clip_result |= CLIP_FLAG_START;
-    if (x1 < 0) {
-      ok = scanLine.intersects(left_border_, start) == QLineF::BoundedIntersection;
-    } else if (x1 > canvas_width_) {
-      ok = scanLine.intersects(right_border_, start) == QLineF::BoundedIntersection;
-    }
-    if (!ok) {
-      if (y1 < 0) {
-        ok = scanLine.intersects(top_border_, start) == QLineF::BoundedIntersection;
-      } else {
-        ok = scanLine.intersects(bottom_border_, start) == QLineF::BoundedIntersection;
-      }
-      if (!ok) {
-        start->setX(x1);
-        start->setY(y1);
-        return -1;
-      }
-    }
-  }
-  double x2 = end->x();
-  double y2 = end->y();
-  bool is_p2_outside = (x2 < 0 || x2 > canvas_width_ || y2 < 0 || y2 > canvas_height_);
-  if (is_p2_outside) {
-    clip_result |= CLIP_FLAG_END;
-    if (x2 < 0) {
-      ok = scanLine.intersects(left_border_, end) == QLineF::BoundedIntersection;
-    } else if (x2 > canvas_width_) {
-      ok = scanLine.intersects(right_border_, end) == QLineF::BoundedIntersection;
-    }
-    if (!ok) {
-      if (y2 < 0) {
-        ok = scanLine.intersects(top_border_, end) == QLineF::BoundedIntersection;
-      } else {
-        ok = scanLine.intersects(bottom_border_, end) == QLineF::BoundedIntersection;
-      }
-      if (!ok) {
-        end->setX(x2);
-        end->setY(y2);
-        return -1;
-      }
-    }
-  }
-  return clip_result;
 }
 
 inline void ToolpathExporter::moveTo(QPointF&& dest, double speed, double power, double x_backlash) {

--- a/src/toolpath_exporter/toolpath-exporter.h
+++ b/src/toolpath_exporter/toolpath-exporter.h
@@ -42,13 +42,16 @@ public:
 
   bool convertStack(const QList<LayerPtr> &layers, bool is_high_speed, bool start_with_home);
 
-  void setWorkAreaSize(QRectF work_area) { machine_work_area_mm_ = work_area; }
+  void setWorkAreaSize(QRectF work_area) {
+    machine_work_area_mm_ = work_area; 
+    path_utils_.setClipRect(work_area.top() * dpmm_, work_area.right() * dpmm_, work_area.bottom() * dpmm_, work_area.left() * dpmm_);
+  }
 
   bool isExceedingBoundary() { return exceed_boundary_; }
 
   void setSortRule(PathSort sort_rule) { sort_rule_ = sort_rule; }
 
-  void setShouldClipWorkarea(bool should_clip_workarea) { should_clip_workarea_ = should_clip_workarea; }
+  void setLoopCompensation(qreal compensation) { path_utils_.setLoopCompensation(compensation / canvas_mm_ratio_ * dpmm_); }
 
   void handleContour() { is_contour_ = true; }
 
@@ -99,7 +102,6 @@ private:
   bool rasterLineHighSpeed(const QLineF& path, const std::vector<std::bitset<32>>& data);
   bool rasterBitmapDepthMode(ScanDirectionMode direction_mode, qreal padding_mm);
 
-  int clipWorkarea(QPointF* start, QPointF* end, bool force);
 
   void onProgressChanged(double value, bool absolute);
 
@@ -140,12 +142,12 @@ private:
   qreal fixed_padding_mm_ = 10;
   QPointF end_point_;
   // ==================================================
-  bool should_clip_workarea_ = false;
   bool is_high_speed_ = false;
   bool exceed_boundary_ = false; // Whether source objects exceeding the work area
   bool with_image_ = false;
   bool cancelled_ = false;
   PathSort sort_rule_;
+  PathUtils path_utils_;
   // ===== Calculate current progress percentage ======
   int total_layer_cnt_ = 1;
   int processed_layer_cnt_ = 0;

--- a/src/toolpath_exporter/toolpath-utils.cpp
+++ b/src/toolpath_exporter/toolpath-utils.cpp
@@ -1,6 +1,7 @@
 #include "toolpath-utils.h"
 #include <algorithm>
 #include <QtMath>
+#include <cmath>
 
 using namespace std;
 /**
@@ -259,4 +260,235 @@ QPolygonF MatFToQPolygon(const cv::Mat& mat) {
     poly << QPointF(pt.x, pt.y);
   }
   return poly;
+}
+
+bool polygonContainsPolygon(const QPolygonF& outer, const QPolygonF& inner) {
+  for (const QPointF& p : inner) {
+    if (!outer.containsPoint(p, Qt::WindingFill)) return false;
+  }
+  return true;
+}
+
+void sortByBoundingRect(QList<QPolygonF>& polys) {
+  std::sort(polys.begin(), polys.end(),
+    [](const QPolygonF& a, const QPolygonF& b) {
+      QRectF bbox_a = a.boundingRect();
+      QRectF bbox_b = b.boundingRect();
+      return bbox_a.width() * bbox_a.height() > bbox_b.width() * bbox_b.height();
+    });
+}
+
+void traverse(QList<QPolygonF>& polys, const NestedPolygonF& node) {
+  for (const auto& child : node.children) {
+    traverse(polys, child);
+  }
+  if (!node.polygon.isEmpty()) {
+    polys.push_back(node.polygon);
+  }
+}
+
+// ================ PathUtils =================
+double PathUtils::getLength(QPointF& start, QPointF& end) {
+  double dx = (end.x() - start.x()) * length_ratio_x_;
+  double dy = (end.y() - start.y()) * length_ratio_y_;
+  return std::sqrt(dx * dx + dy * dy);
+}
+
+void PathUtils::loopCompensate(QPolygonF& poly) {
+  if (!should_compensate_ || !poly.isClosed()) return;
+
+  QPointF curr, next;
+  double lineLength;
+  double distance = loop_compensation_;
+  int ptsSize = poly.size();
+  for (int i = 1; i < ptsSize && distance >= 0.0001; ++i) {
+    curr = poly[i - 1];
+    next = poly[i];
+    lineLength = getLength(curr, next);
+    if (lineLength > distance) {
+      poly << QLineF(curr, next).pointAt(distance / lineLength);
+      break;
+    } else {
+      poly << next;
+      distance -= lineLength;
+    }
+  }
+}
+
+int PathUtils::clipWorkarea(QPointF* start, QPointF* end) {
+  int clip_result = 0;
+  QLineF scanLine(*start, *end);
+  bool ok = false;
+  double x1 = start->x();
+  double y1 = start->y();
+  bool is_p1_outside = (x1 < left_x_ || x1 > right_x_ || y1 < top_y_ || y1 > bottom_y_);
+  if (is_p1_outside) {
+    clip_result |= CLIP_FLAG_START;
+    if (x1 < left_x_) {
+      ok = scanLine.intersects(left_border_, start) == QLineF::BoundedIntersection;
+    } else if (x1 > right_x_) {
+      ok = scanLine.intersects(right_border_, start) == QLineF::BoundedIntersection;
+    }
+    if (!ok) {
+      if (y1 < top_y_) {
+        ok = scanLine.intersects(top_border_, start) == QLineF::BoundedIntersection;
+      } else {
+        ok = scanLine.intersects(bottom_border_, start) == QLineF::BoundedIntersection;
+      }
+      if (!ok) {
+        start->setX(x1);
+        start->setY(y1);
+        return -1;
+      }
+    }
+  }
+
+  ok = false;
+  double x2 = end->x();
+  double y2 = end->y();
+  bool is_p2_outside = (x2 < left_x_ || x2 > right_x_ || y2 < top_y_ || y2 > bottom_y_);
+  if (is_p2_outside) {
+    clip_result |= CLIP_FLAG_END;
+    if (x2 < left_x_) {
+      ok = scanLine.intersects(left_border_, end) == QLineF::BoundedIntersection;
+    } else if (x2 > right_x_) {
+      ok = scanLine.intersects(right_border_, end) == QLineF::BoundedIntersection;
+    }
+    if (!ok) {
+      if (y2 < top_y_) {
+        ok = scanLine.intersects(top_border_, end) == QLineF::BoundedIntersection;
+      } else {
+        ok = scanLine.intersects(bottom_border_, end) == QLineF::BoundedIntersection;
+      }
+      if (!ok) {
+        end->setX(x2);
+        end->setY(y2);
+        return -1;
+      }
+    }
+  }
+  return clip_result;
+}
+
+void PathUtils::preprocessPath(QList<NestedPolygonF>& polys) {
+  int original_size = polys.size();
+  for (int p = 0; p < original_size; ++p) {
+    QPolygonF poly = polys[p].polygon;
+    if (poly.isEmpty()) continue;
+
+    QPolygonF clipped_poly;
+    bool is_first = true;
+    for (int i = 1; i < poly.size(); ++i) {
+      QPointF curr = poly[i - 1];
+      QPointF next = poly[i];
+      int clip_result = clipWorkarea(&curr, &next);
+      if (clip_result == -1) continue;
+      if (clipped_poly.isEmpty()) {
+        clipped_poly << curr;
+      }
+      clipped_poly << next;
+      if ((clip_result & CLIP_FLAG_END) || (i == poly.size() - 1)) {
+        if (should_compensate_) {
+          loopCompensate(clipped_poly);
+        }
+        if (is_first) {
+          polys[p].polygon = std::move(clipped_poly);
+          is_first = false;
+        } else {
+          NestedPolygonF clipped_item = {std::move(clipped_poly), {}};
+          polys.push_back(std::move(clipped_item));
+        }
+      }
+    }
+    if (is_first) {
+      // All points are outside workarea
+      polys.removeAt(p);
+      --p;
+      --original_size;
+    }
+  }
+}
+
+void PathUtils::sortByDistance(QList<NestedPolygonF>& polys) {
+  QList<NestedPolygonF> sorted_polys;
+  if (polys.empty()) return;
+
+  preprocessPath(polys);
+
+  auto currentIter = polys.begin();
+  bool needReverse = false;
+  auto minIter = polys.end();
+  float minDist;
+  float d;
+  QPointF currentEnd;
+  while (currentIter < polys.end()) {
+    if (needReverse) {
+      std::reverse(currentIter->polygon.begin(), currentIter->polygon.end());
+    }
+    sorted_polys.push_back(std::move(*currentIter));
+    currentEnd = sorted_polys.back().polygon.last();
+    polys.erase(currentIter);
+    minDist = NAN;
+    minIter = polys.begin();
+
+    for (auto it = polys.begin(); it != polys.end(); ++it) {
+      d = getLength(currentEnd, it->polygon.first());
+      if (std::isnan(minDist) || d < minDist) {
+        minDist = d;
+        minIter = it;
+        needReverse = false;
+      }
+
+      d = getLength(currentEnd, it->polygon.last());
+      if (d < minDist) {
+        minDist = d;
+        minIter = it;
+        needReverse = true;
+      }
+    }
+    currentIter = minIter;
+  }
+
+  polys = std::move(sorted_polys);
+}
+
+void PathUtils::findChildren(QList<QPolygonF>& polys, NestedPolygonF& parent, int index) {
+  if (polys.empty()) return;
+
+  for (; index < polys.size();) {
+    if (polygonContainsPolygon(parent.polygon, polys[index])) {
+      NestedPolygonF child;
+      child.polygon = polys[index];
+      parent.children.push_back(std::move(child));
+      polys.removeAt(index);
+      findChildren(polys, parent.children.back(), index);
+    } else {
+      ++index;
+    }
+  }
+  sortByDistance(parent.children);
+}
+
+/**
+ * Sort polygons by nested containment relationship
+ * Clip polygons to the working area
+ * Add loop compensation if needed
+ * Optimize travel distance in same containment level
+ */
+void PathUtils::sortAndPreprocessPolygons(QList<QPolygonF>& polys) {
+  NestedPolygonF root;
+  // Sort by bounding rect for some containment relationship hints
+  sortByBoundingRect(polys);
+
+  while (!polys.isEmpty()) {
+    NestedPolygonF front;
+    front.polygon = polys.front();
+    polys.pop_front();
+    findChildren(polys, front, 0);
+    root.children.push_back(std::move(front));
+  }
+
+  sortByDistance(root.children);
+  polys.clear();
+  traverse(polys, root);
 }

--- a/src/toolpath_exporter/toolpath-utils.h
+++ b/src/toolpath_exporter/toolpath-utils.h
@@ -14,6 +14,14 @@ using namespace std;
 constexpr int WHITE_PIXEL = 255; // should ignored
 constexpr int BLACK_PIXEL = 0; // should emit
 
+constexpr int CLIP_FLAG_START = 0b01;
+constexpr int CLIP_FLAG_END = 0b10;
+
+struct NestedPolygonF {
+  QPolygonF polygon;
+  QList<NestedPolygonF> children;
+};
+
 using Bitset32 = bitset<32>;
 using ByteArray32 = array<unsigned char, 32>;
 using namespace std;
@@ -27,3 +35,51 @@ bool findMinMaxPixel(QImage* img, int* min_pixel, int* max_pixel);
 cv::Mat QPolygonToMat(const QPolygonF& poly);
 QPolygon MatIToQPolygon(const cv::Mat& mat);
 QPolygonF MatFToQPolygon(const cv::Mat& mat);
+
+bool polygonContainsPolygon(const QPolygonF& outer, const QPolygonF& inner);
+void sortByBoundingRect(QList<QPolygonF>& polys);
+void traverse(QList<QPolygonF>& polys, const NestedPolygonF& node);
+
+class PathUtils {
+ public:
+  void setLengthRatio(double x, double y) {
+    length_ratio_x_ = x;
+    length_ratio_y_ = y;
+  }
+  void setLoopCompensation(double loop_compensation) {
+    loop_compensation_ = loop_compensation;
+    should_compensate_ = loop_compensation_ > 0;
+  }
+  void setClipRect(double top_y, double right_x, double bottom_y, double left_x) {
+    top_y_ = top_y;
+    right_x_ = right_x;
+    bottom_y_ = bottom_y;
+    left_x_ = left_x;
+    top_border_ = QLineF(left_x_, top_y_, right_x_, top_y_);
+    right_border_ = QLineF(right_x_, top_y_, right_x_, bottom_y_);
+    bottom_border_ = QLineF(right_x_, bottom_y_, left_x_, bottom_y_);
+    left_border_ = QLineF(left_x_, bottom_y_, left_x_, top_y_);
+  }
+  int clipWorkarea(QPointF* start, QPointF* end);
+  void sortAndPreprocessPolygons(QList<QPolygonF>& polys);
+
+ private:
+  void findChildren(QList<QPolygonF>& polys, NestedPolygonF& parent, int index);
+  void sortByDistance(QList<NestedPolygonF>& polys);
+  void preprocessPath(QList<NestedPolygonF>& polys);
+  void loopCompensate(QPolygonF& poly);
+  double getLength(QPointF& start, QPointF& end);
+
+  double length_ratio_x_ = 1;
+  double length_ratio_y_ = 1;
+  bool should_compensate_ = false;
+  double loop_compensation_ = 0;
+  double top_y_ = 0;
+  double right_x_ = 0;
+  double bottom_y_ = 0;
+  double left_x_ = 0;
+  QLineF top_border_;
+  QLineF right_border_;
+  QLineF bottom_border_;
+  QLineF left_border_;
+};


### PR DESCRIPTION
https://app.clickup.com/t/86erw69a2

修正 一般機型 中 loop_compensation 的效果
增加 Promark loop_compensation

修正 一般機型 封閉路徑順序計算方式
增加 Promark 封閉路徑順序

調整 不論算圖參數是否有給 mask，總是執行工作範圍剪裁
更新 一般機型 工作範圍剪裁的實作方式，統一使用 Promark 版本
修正 工作範圍剪裁 在特定情況下結果錯誤 （兩點都需要裁剪，且第二個點是 y 超出範圍時。處理完第一個點後沒有重置 ok 的值，第二個點就不會被裁剪）

修正 一般機型 在路徑預覽（Gcode）時，坐標點可能採用科學記號導致 BS 無法正確辨識數值

移除 blade 相關功能（deprecated）