### PR TITLE
Fix beam studio exporter

### DIFF
--- a/src/parser/my_qsvg_handler_qt6.cpp
+++ b/src/parser/my_qsvg_handler_qt6.cpp
@@ -5084,6 +5084,13 @@ bool MyQSvgHandler::startElement(const QString &localName,
                 cssStyleLookup(node, this, m_selector);
 #endif
                 parseStyle(node, attributes, this);
+                if (localName == QLatin1String("line")) {
+                    // Force clear fill for line element
+                    auto fillStyle = node->styleProperty(QSvgStyleProperty::FILL);
+                    if (fillStyle) {
+                        ((QSvgFillStyle*)fillStyle)->setBrush(QBrush(Qt::NoBrush));
+                    }
+                }
                 if (node->type() == QSvgNode::Text || node->type() == QSvgNode::Textarea) {
                     static_cast<QSvgText *>(node)->setWhitespaceMode(m_whitespaceMode.top());
                 } else if (node->type() == QSvgNode::Tspan) {

--- a/src/toolpath_exporter/factories/printer.cpp
+++ b/src/toolpath_exporter/factories/printer.cpp
@@ -479,9 +479,9 @@ PacketData PrinterBitmapFactory::create_image_packet_data(
     }
     if (column_count > 0) {
       if (min_data_idx < 0) {
-        min_data_idx = c;
+        min_data_idx = i;
       }
-      max_data_idx = c;
+      max_data_idx = i;
       px_count += column_count;
     }
     payload_data.append(column_payload);

--- a/src/toolpath_exporter/generators/fcode-generator.cpp
+++ b/src/toolpath_exporter/generators/fcode-generator.cpp
@@ -677,8 +677,11 @@ unsigned long FCodeGeneratorV2::write_metadata() {
   for (auto it = metadata.begin(); it != metadata.end(); ++it) {
     // Note: REQUIRED_HEADTYPE and FORBIDDEN_HEADTYPE must be number without
     // quotes
-    write_metadata_(it.key(), it.value().toString(), &crc_val,
-                    !it.value().isDouble());
+    if (it.value().isDouble()) {
+      write_metadata_(it.key(), QString::number(it.value().toInt()), &crc_val, false);
+    } else {
+      write_metadata_(it.key(), it.value().toString(), &crc_val);
+    }
   }
   write_metadata_("version", "2", &crc_val);
   write_metadata_("CREATED_AT", created_at.toString(time_format), &crc_val);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -647,7 +647,7 @@ void ToolpathExporterFcode::convertLayer() {
     QJsonObject submodule{{"color", "None"}};
     QString submodule_type = "None";
     if (layer_module_ == LayerModule::PRINTER) {
-      QString submodule_type = "Solvent";
+      submodule_type = "Solvent";
       submodule["color"] = COLOR_NAME_MAP.value(layer_color_, "black");
     }
     submodule["type"] = submodule_type;


### PR DESCRIPTION
1. Handle line with `fill` correctly https://app.clickup.com/t/86ewgzv2j
2. Fix numeric metadata https://app.clickup.com/t/86ewh0rcg
3. Fix printer ink type not updated https://app.clickup.com/t/86ewh0rvc
4. Fix printer factory