### PR TITLE
Add s-curve time estimation

### DIFF
--- a/src/toolpath_exporter/generators/estimate_time.cpp
+++ b/src/toolpath_exporter/generators/estimate_time.cpp
@@ -7,6 +7,88 @@ static float estimate_vel(float last_vel, float dist_vel, float acc, float dist)
   return fmin(dist_vel, powf(pow(last_vel, 2) + 2 * acc * dist, 0.5));
 }
 
+// S-curve acceleration from v0 to v_target, returns time and distance via output pointers
+static void s_curve_accel(float v0, float v_target, float a0, float a_max, float jerk,
+                          float *out_time, float *out_dist) {
+  float dv = v_target - v0;
+  if (dv <= 0) {
+    *out_time = 0;
+    *out_dist = 0;
+    return;
+  }
+
+  // phase 1: accel ramp up (a0 -> a_max)
+  float t1 = (a_max - a0) / jerk;
+  float dv1 = a0 * t1 + 0.5f * jerk * t1 * t1;
+
+  // phase 3: accel ramp down (a_max -> a0)
+  float t3 = t1; // symmetric
+  float dv3 = a_max * t3 - 0.5f * jerk * t3 * t3;
+
+  float dv_jerk = dv1 + dv3;
+
+  if (dv_jerk >= dv) {
+    // Triangular case: a_peak < a_max, only 2 phases
+    float a_peak = sqrtf(jerk * dv + a0 * a0);
+
+    float t1_tri = (a_peak - a0) / jerk;
+    float s1 = v0 * t1_tri + 0.5f * a0 * t1_tri * t1_tri + (1.0f / 6.0f) * jerk * t1_tri * t1_tri * t1_tri;
+    float v1 = v0 + a0 * t1_tri + 0.5f * jerk * t1_tri * t1_tri;
+
+    float t3_tri = t1_tri; // symmetric
+    float s3 = v1 * t3_tri + 0.5f * a_peak * t3_tri * t3_tri - (1.0f / 6.0f) * jerk * t3_tri * t3_tri * t3_tri;
+
+    *out_time = t1_tri + t3_tri;
+    *out_dist = s1 + s3;
+  } else {
+    // Full case: 3 phases (jerk up, constant accel, jerk down)
+    float t2 = (dv - dv_jerk) / a_max;
+
+    float s1 = v0 * t1 + 0.5f * a0 * t1 * t1 + (1.0f / 6.0f) * jerk * t1 * t1 * t1;
+    float v1 = v0 + dv1;
+    float s2 = v1 * t2 + 0.5f * a_max * t2 * t2;
+    float v2 = v1 + a_max * t2;
+    float s3 = v2 * t3 + 0.5f * a_max * t3 * t3 - (1.0f / 6.0f) * jerk * t3 * t3 * t3;
+
+    *out_time = t1 + t2 + t3;
+    *out_dist = s1 + s2 + s3;
+  }
+}
+
+// Estimate move time for pure X motion with S-curve acceleration.
+// Assumes each line starts from 0 and decelerates to 0 (symmetric).
+// Handles velocity capping for short distances via binary search.
+static float estimate_time_s_curve(float feedrate, float a0, float a_max, float jerk, float dist) {
+  if (feedrate <= 0 || dist <= 0) return 0;
+
+  float accel_time, accel_dist;
+  s_curve_accel(0, feedrate, a0, a_max, jerk, &accel_time, &accel_dist);
+  // decel is symmetric: same time and distance
+  float total_ramp_dist = accel_dist * 2;
+
+  if (total_ramp_dist <= dist) {
+    // Enough room: accel + cruise + decel
+    float cruise_dist = dist - total_ramp_dist;
+    return accel_time * 2 + cruise_dist / feedrate;
+  }
+
+  // Not enough room to reach feedrate, binary search for max vel
+  float lo = 0, hi = feedrate;
+  for (int i = 0; i < 20; i++) {
+    float mid = (lo + hi) * 0.5f;
+    s_curve_accel(0, mid, a0, a_max, jerk, &accel_time, &accel_dist);
+    if (accel_dist * 2 <= dist) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  s_curve_accel(0, lo, a0, a_max, jerk, &accel_time, &accel_dist);
+  float cruise_dist = dist - accel_dist * 2;
+  if (cruise_dist < 0) cruise_dist = 0;
+  return accel_time * 2 + cruise_dist / fmax(lo, 0.001f);
+}
+
 static float estimate_time(float last_speed, float last_vel_n, float last_vel_t, float vel, float last_acc, float acc, float dist) {
   if (last_vel_t < 0) {
     // if last_vel_t is negative, the direction is changed, need to de-accelerate the whole last_speed

--- a/src/toolpath_exporter/generators/fcode-generator.cpp
+++ b/src/toolpath_exporter/generators/fcode-generator.cpp
@@ -56,6 +56,16 @@ void FCodeGenerator::set_time_est_z_speed(float value) {
   z_speed = value;
 }
 
+void FCodeGenerator::set_s_curve_params(float a0, float a_max, float jerk) {
+  s_curve_a0 = a0;
+  s_curve_a_max = a_max;
+  s_curve_jerk = jerk;
+}
+
+void FCodeGenerator::set_s_curve_enabled(bool enabled) {
+  s_curve_enabled = enabled;
+}
+
 void FCodeGenerator::moveto(int flags,
                             float feedrate,
                             float x,
@@ -353,10 +363,17 @@ void FCodeGeneratorV1::moveto(int flags,
         float acc = (abs(mv[0]) / acc_x) > (abs(mv[1]) / acc_y) ? acc_x : acc_y;
         if (last_acc == 0)
           last_acc = acc;
-        float vel = estimate_vel(last_vel_t, current_feedrate, acc,
-                                 dist);  // consider short distance
-        float tc = estimate_time(last_feedrate, last_vel_n, last_vel_t, vel,
-                                 last_acc, acc, dist);
+        float vel;
+        float tc;
+        if (s_curve_enabled && mv[1] == 0) {
+          tc = estimate_time_s_curve(current_feedrate, s_curve_a0, s_curve_a_max, s_curve_jerk, dist);
+          vel = 0;
+        } else {
+          vel = estimate_vel(last_vel_t, current_feedrate, acc,
+                             dist);  // consider short distance
+          tc = estimate_time(last_feedrate, last_vel_n, last_vel_t, vel,
+                             last_acc, acc, dist);
+        }
         if (!isnan(tc))
           time_cost += tc;
         last_feedrate = vel;
@@ -623,9 +640,16 @@ void FCodeGeneratorV2::moveto(int flags,
         float acc = (abs(mv[0]) / acc_x) > (abs(mv[1]) / acc_y) ? acc_x : acc_y;
         if (last_acc == 0)
           last_acc = acc;
-        float vel = estimate_vel(last_vel_t, current_feedrate, acc, dist);
-        float res = estimate_time(last_feedrate, last_vel_n, last_vel_t, vel,
-                                  last_acc, acc, dist);
+        float vel;
+        float res;
+        if (s_curve_enabled && mv[1] == 0) {
+          res = estimate_time_s_curve(current_feedrate, s_curve_a0, s_curve_a_max, s_curve_jerk, dist);
+          vel = 0;
+        } else {
+          vel = estimate_vel(last_vel_t, current_feedrate, acc, dist);
+          res = estimate_time(last_feedrate, last_vel_n, last_vel_t, vel,
+                              last_acc, acc, dist);
+        }
         if (!isnan(res) && res > time_est)
           time_est = res;
         last_feedrate = vel;

--- a/src/toolpath_exporter/generators/fcode-generator.h
+++ b/src/toolpath_exporter/generators/fcode-generator.h
@@ -59,6 +59,10 @@ class FCodeGenerator {
   float acc_x = 4000;
   float acc_y = 2000;
   float z_speed = 7.5;
+  bool s_curve_enabled = false;
+  float s_curve_a0 = 0;
+  float s_curve_a_max = 0;
+  float s_curve_jerk = 0;
   QJsonObject metadata{};
 
   virtual void write(const char* buf,
@@ -95,6 +99,8 @@ class FCodeGenerator {
 
   void set_time_est_acc(uint32_t x, uint32_t y = 2000);
   void set_time_est_z_speed(float value);
+  void set_s_curve_params(float a0, float a_max, float jerk);
+  void set_s_curve_enabled(bool enabled);
   virtual void moveto(int flags,
                       float feedrate,
                       float x,
@@ -384,6 +390,8 @@ class ToolpathProcessor {
   FORWARD_TO_GENERATOR(fill_32_pixels)
   FORWARD_TO_GENERATOR(set_time_est_acc)
   FORWARD_TO_GENERATOR(set_time_est_z_speed)
+  FORWARD_TO_GENERATOR(set_s_curve_params)
+  FORWARD_TO_GENERATOR(set_s_curve_enabled)
   FORWARD_TO_GENERATOR(set_fill_end)
   FORWARD_TO_GENERATOR(set_print_line_status)
   FORWARD_TO_GENERATOR(enter_printer_mode)

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -883,6 +883,11 @@ void ToolpathExporterFcode::outputBitmapFcode() {
       qInfo() << "Enable S-Curve with padding distance:" << s_curve_padding << "mm";
       padding_dist = s_curve_padding;
       proc.sync_motion_type2(156, 1);
+      auto s_curve_params = get_s_curve_parameters(hardware_, layer_speed_ / 60.0);
+      if (s_curve_params) {
+        proc.set_s_curve_params(s_curve_params->a0, s_curve_params->a_max, s_curve_params->jerk);
+        proc.set_s_curve_enabled(true);
+      }
     }
   }
 
@@ -903,6 +908,7 @@ void ToolpathExporterFcode::outputBitmapFcode() {
   }
   if (!isnan(s_curve_padding)) {
     proc.sync_motion_type2(156);
+    proc.set_s_curve_enabled(false);
   }
 }
 

--- a/src/toolpath_exporter/toolpath-utils.cpp
+++ b/src/toolpath_exporter/toolpath-utils.cpp
@@ -814,13 +814,6 @@ double get_padding_dist(double min_padding, float speed, float acc) {
   return qMax((pow(speed, 2)) / (2.0 * acc), qMax(min_padding, 0.0));
 }
 
-namespace {
-struct SCurveParameters {
-  double a0;
-  double a_max;
-  double jerk;
-};
-
 // Returns s-curve motion parameters for the given hardware/speed, or
 // std::nullopt if the hardware does not support s-curve.
 // Mirrors fluxclient/hw_profile/s_curve.py::get_s_curve_parameters.
@@ -840,7 +833,6 @@ std::optional<SCurveParameters> get_s_curve_parameters(HardwareType hw_type,
   }
   return std::nullopt;
 }
-}  // namespace
 
 double get_s_curve_padding_dist(HardwareType hw_type, float speed, double v0) {
   auto params = get_s_curve_parameters(hw_type, speed);

--- a/src/toolpath_exporter/toolpath-utils.h
+++ b/src/toolpath_exporter/toolpath-utils.h
@@ -8,6 +8,7 @@
 #include <opencv2/core.hpp>
 #include <array>
 #include <bitset>
+#include <optional>
 #include <vector>
 
 std::tuple<std::vector<Bitset32>, uint32_t, uint32_t> adjustPrefixSuffixZero(
@@ -101,6 +102,15 @@ double get_default_min_padding(
     bool is_high_quality = false);
 
 double get_padding_dist(double min_padding, float speed, float acc);
+
+struct SCurveParameters {
+  double a0;
+  double a_max;
+  double jerk;
+};
+
+std::optional<SCurveParameters> get_s_curve_parameters(HardwareType hw_type,
+                                                       float speed);
 
 /**
  * Compute the S-curve acceleration padding distance for the given hardware


### PR DESCRIPTION
# Description

add time estimation for s curve engraving. Always assume the segment start and end at v=0 for convenience of calculation

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test the actual time cost on the machine
