### PR TITLE
Fix resize after convert image

### DIFF
--- a/src/toolpath_exporter/factories/base-factory.cpp
+++ b/src/toolpath_exporter/factories/base-factory.cpp
@@ -37,9 +37,8 @@ BaseBitmapFactory::BaseBitmapFactory(const FactoryKwargs& kwargs) noexcept
     workspaces = new QVector<std::shared_ptr<Workspace>>();
     use_own_workspaces = true;
   }
-  // Note: Use pixel_per_mm for both x and y during drawing and bitmap conversion and pixel_per_mm_x for x after drawing
-  // work_area and clip_rect is recalculated to use pixel_per_mm in Workspace
-  transform = QTransform::fromScale(pixel_per_mm, pixel_per_mm);
+  // Workspace bitmap uses native dpmm_x/dpmm_y resolution directly
+  transform = QTransform::fromScale(pixel_per_mm_x, pixel_per_mm);
   work_area = QSize(std::ceil(work_area_mm.width() * pixel_per_mm_x),
                     std::ceil(work_area_mm.height() * pixel_per_mm));
   pixel_size = 1 / pixel_per_mm;
@@ -86,7 +85,7 @@ std::shared_ptr<Workspace> BaseBitmapFactory::get_workspace(int index,
   }
   auto& workspace = workspaces->at(index);
   if (need_setup && !is_workspace_valid(index)) {
-    workspace->set_size(work_area.width(), work_area.height(), pixel_per_mm_x, pixel_per_mm);
+    workspace->set_size(work_area.width(), work_area.height());
     setup_clip_rect(workspace);
     if (is_valid.size() <= index) {
       is_valid.resize(index + 1);

--- a/src/toolpath_exporter/factories/workspace.cpp
+++ b/src/toolpath_exporter/factories/workspace.cpp
@@ -3,7 +3,6 @@
 
 void Workspace::setup_canvas() {
   if (bitmap_ready) return;
-  bitmap_scaled = QImage();
   if (bitmap.width() >= canvas_width && bitmap.height() >= canvas_height) {
     // Clear old content
     QPainter painter(&bitmap);
@@ -14,21 +13,18 @@ void Workspace::setup_canvas() {
     bitmap.fill(Qt::white);
   }
   bitmap_dirty_area = QRectF();
-  bitmap_dirty_area_scaled = QRectF();
   bitmap_ready = true;
   updated = false;
 }
 
-void Workspace::set_size(int width, int height, double dpmm_x, double dpmm_y) {
-  scale = dpmm_x / dpmm_y;
-  canvas_width = fmax(width / scale, 1);
+void Workspace::set_size(int width, int height) {
+  canvas_width = fmax(width, 1);
   canvas_height = fmax(height, 1);
   bitmap_ready = false;
 }
 
 void Workspace::set_clip_rect(QRect& clip_rect) {
-  this->clip_rect = QRect(clip_rect.x() / scale, clip_rect.y(),
-                          clip_rect.width() / scale, clip_rect.height());
+  this->clip_rect = clip_rect;
 }
 
 void Workspace::add_image(QImage& img, QRectF& bbox) {
@@ -55,20 +51,12 @@ void Workspace::add_filled_path(QPainterPath& path, QRectF& bbox) {
 QRectF Workspace::get_dirty_area() {
   if (updated) {
     bitmap_dirty_area = bitmap_dirty_area.intersected(clip_rect);
-    bitmap_dirty_area_scaled = QRectF(bitmap_dirty_area.x() * scale, bitmap_dirty_area.y(),
-                                      bitmap_dirty_area.width() * scale, bitmap_dirty_area.height());
     updated = false;
   }
-  return bitmap_dirty_area_scaled;
+  return bitmap_dirty_area;
 }
 
 QImage* Workspace::get_bitmap() {
-  if (scale != 1) {
-    if (bitmap_scaled.isNull()) {
-      bitmap_scaled = bitmap.scaled(canvas_width * scale, canvas_height);
-    }
-    return &bitmap_scaled;
-  }
   return &bitmap;
 }
 

--- a/src/toolpath_exporter/factories/workspace.h
+++ b/src/toolpath_exporter/factories/workspace.h
@@ -9,22 +9,19 @@
 class Workspace {
  private:
   QImage bitmap;
-  QImage bitmap_scaled; // For high dpi laser layers with varied dpmm and dpmm_x
   bool bitmap_ready = false;
   QRect clip_rect = QRect();
   QRectF bitmap_dirty_area = QRectF();
-  QRectF bitmap_dirty_area_scaled = QRectF();
   bool updated = false;
   int canvas_width = 1;
   int canvas_height = 1;
-  double scale = 1.0;
 
   void setup_canvas();
 
  public:
   Workspace() = default;
 
-  void set_size(int width, int height, double dpmm_x = 1.0, double dpmm_y = 1.0);
+  void set_size(int width, int height);
   void set_clip_rect(QRect& clip_rect);
   void add_image(QImage& img, QRectF& bbox);
   void add_filled_path(QPainterPath& path, QRectF& bbox);

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -1303,13 +1303,15 @@ void ToolpathExporterFcode::clearTransparent(QImage* src) {
   Q_ASSERT_X(src->format() == QImage::Format_ARGB32, "ToolpathExporterFcode",
              "Input image for clearTransparent() must be Format_ARGB32");
 
-  QRgb white = 0xFFFFFFFF;
   for (int y = 0; y < src->height(); ++y) {
     QRgb* ptr = (QRgb*)src->scanLine(y);
     for (int x = 0; x < src->width(); ++x) {
-      if (qAlpha(ptr[x]) == 0) {
-        ptr[x] = white;
-      }
+      int alpha = qAlpha(ptr[x]);
+      if (alpha == 255) continue;
+      // composite with white background
+      int gray = qGray(ptr[x]);
+      int blended = (gray * alpha + 255 * (255 - alpha)) / 255;
+      ptr[x] = qRgba(blended, blended, blended, 255);
     }
   }
 }

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -1213,6 +1213,9 @@ void ToolpathExporterFcode::convertBitmap(const BitmapShape* bmp) {
           .transformed(transform, bmp->gradient() ? Qt::SmoothTransformation
                                                   : Qt::FastTransformation)
           .convertToFormat(QImage::Format_ARGB32);
+  // Note: width and height of new_dirty_area could be floating point, use transformed_image's width and height instead to prevent rounding issue
+  new_dirty_area.setWidth(transformed_image.width());
+  new_dirty_area.setHeight(transformed_image.height());
   if (bmp->gradient()) {
     if (!is_laser_layer_) {
       if (layer_module_ == LayerModule::PRINTER_4C) {

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -711,10 +711,11 @@ void ToolpathExporterFcode::preprocessLaserLayer() {
                                           : 10;  // fallback to medium
   int dpmm_x = qMin(dpmm_y, hw_profile.max_pixel_per_mm_x);
 
-  int kernel_size = dpmm_y >= 10 ? std::round(2 * config_.engraving_erode * dpmm_y) + 1 : 0;
-  if (kernel_size > 1) {
+  int kernel_size_y = dpmm_y >= 10 ? std::round(2 * config_.engraving_erode * dpmm_y) + 1 : 0;
+  if (kernel_size_y > 1) {
+    int kernel_size_x = dpmm_x >= 10 ? std::round(2 * config_.engraving_erode * dpmm_x) + 1 : 1;
     kernel_ = cv::getStructuringElement(cv::MORPH_ELLIPSE,
-                                        cv::Size(kernel_size, kernel_size));
+                                        cv::Size(kernel_size_x, kernel_size_y));
   } else {
     kernel_.release();
   }

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -711,6 +711,7 @@ void ToolpathExporterFcode::preprocessLaserLayer() {
                                           : 10;  // fallback to medium
   int dpmm_x = qMin(dpmm_y, hw_profile.max_pixel_per_mm_x);
 
+  // use y to determine auto shrink or not because dpmm_y >= dpmm_x
   int kernel_size_y = dpmm_y >= 10 ? std::round(2 * config_.engraving_erode * dpmm_y) + 1 : 0;
   if (kernel_size_y > 1) {
     int kernel_size_x = dpmm_x >= 10 ? std::round(2 * config_.engraving_erode * dpmm_x) + 1 : 1;


### PR DESCRIPTION
# Description

Currently, if dpmm_x != dpmm_y, ths workspace will resize bitmap when get_bitmap after image processing and cause loss of data.
Remove scale and keep the bitmap size as `width * dpmm_x` x `height * dpmm_y`.
Also set the transform of BaseBitmapFactory to dpmm_x, dpmm_y

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
