### PR TITLE
Update s_curve_enable default value

### DIFF
--- a/src/parser/my_qsvg_handler_qt6.cpp
+++ b/src/parser/my_qsvg_handler_qt6.cpp
@@ -2953,7 +2953,7 @@ static QSvgNode *createGNode(QSvgNode *parent,
         layer_config.laser_delay = getAttr(attributes, "data-delay", default_config, "delay", 0);
         layer_config.dpmm = getAttr(attributes, "data-dpmm", default_config, "dpmm", 0);
         layer_config.is_high_quality = getAttr(attributes, "data-highQuality", default_config, "highQuality", 0) == 1;
-        layer_config.s_curve_enable = getAttr(attributes, "data-scEnable", default_config, "scEnable", 0) == 1;
+        layer_config.s_curve_enable = getAttr(attributes, "data-scEnable", default_config, "scEnable", 1) == 1;
         layer_config.s_curve_a0 = getAttr(attributes, "data-scA0", default_config, "scA0", 0.0);
         layer_config.s_curve_a_max = getAttr(attributes, "data-scAMax", default_config, "scAMax", 0.0);
         layer_config.s_curve_jerk = getAttr(attributes, "data-scJerk", default_config, "scJerk", 0.0);


### PR DESCRIPTION
# Description

Set s_curve_enable layer parameter default to true for old .beam without the parameter

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
