### PR TITLE
Add per-layer printing padding overrides

### DIFF
--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -170,6 +170,10 @@ int Layer::interpolation() const { return interpolation_; }
 
 double Layer::rightPadding() const { return right_padding_; }
 
+int Layer::printingTopPadding() const { return printing_top_padding_; }
+
+int Layer::printingBotPadding() const { return printing_bot_padding_; }
+
 int Layer::uvPrintingRepeat() const { return uv_printing_repeat_; }
 
 int Layer::uvCuringAfter() const { return uv_curing_after_; }
@@ -310,6 +314,8 @@ void Layer::setParameters(const MySVG::BeamLayerConfig &config) {
   this->ce_z_limit_ = config.ce_z_limit;
   this->interpolation_ = config.interpolation;
   this->right_padding_ = config.right_padding;
+  this->printing_top_padding_ = config.printing_top_padding;
+  this->printing_bot_padding_ = config.printing_bot_padding;
   this->uv_printing_repeat_ = config.uv_printing_repeat;
   this->uv_curing_after_ = config.uv_curing_after;
   this->uv_curing_repeat_ = config.uv_curing_repeat;

--- a/src/layer.h
+++ b/src/layer.h
@@ -101,6 +101,8 @@ public:
   double ceZLimit() const;
   int interpolation() const;
   double rightPadding() const;
+  int printingTopPadding() const;
+  int printingBotPadding() const;
   int uvPrintingRepeat() const;
   int uvCuringAfter() const;
   int uvCuringRepeat() const;
@@ -201,6 +203,9 @@ private:
   // UV configs
   int interpolation_ = 1;
   double right_padding_ = 0;
+  // px, -1 for unset, overrides the global printing paddings when >= 0
+  int printing_top_padding_ = -1;
+  int printing_bot_padding_ = -1;
   int uv_printing_repeat_ = 1;
   int uv_curing_after_ = 0;
   int uv_curing_repeat_ = 1;

--- a/src/parser/my_qsvg_handler_qt6.cpp
+++ b/src/parser/my_qsvg_handler_qt6.cpp
@@ -2934,6 +2934,8 @@ static QSvgNode *createGNode(QSvgNode *parent,
         layer_config.ce_z_limit = getAttr(attributes, "data-ceZSpeedLimit", default_config, "ceZSpeedLimit", 0.0);
         layer_config.interpolation = getAttr(attributes, "data-interpolation", default_config, "interpolation", 1);
         layer_config.right_padding = getAttr(attributes, "data-rightPadding", default_config, "right_padding", 0.0);
+        layer_config.printing_top_padding = getAttr(attributes, "data-printingTopPadding", default_config, "printingTopPadding", -1);
+        layer_config.printing_bot_padding = getAttr(attributes, "data-printingBotPadding", default_config, "printingBotPadding", -1);
         layer_config.uv_printing_repeat = getAttr(attributes, "data-uvPrintingRepeat", default_config, "uv_printing_repeat", 1);
         layer_config.uv_curing_after = getAttr(attributes, "data-uvCuringAfter", default_config, "uv_curing_after", 0);
         layer_config.uv_curing_repeat = getAttr(attributes, "data-uvCuringRepeat", default_config, "uv_curing_repeat", 1);

--- a/src/parser/mysvg/mysvg-types.h
+++ b/src/parser/mysvg/mysvg-types.h
@@ -68,6 +68,9 @@ namespace MySVG {
         double ce_z_limit;
         int interpolation;
         double right_padding;
+        // px, -1 for unset, overrides the global printing paddings when >= 0
+        int printing_top_padding;
+        int printing_bot_padding;
         int uv_printing_repeat;
         int uv_curing_after;
         int uv_curing_repeat;

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -1006,8 +1006,11 @@ void ToolpathExporterFcode::convertPrintingLayer() {
     }
     factory_->set_slice_width(config_.printing_slice_width);
     factory_->set_slice_height(config_.printing_slice_height);
-    factory_->set_slice_top_padding(config_.printing_top_padding);
-    factory_->set_slice_bot_padding(config_.printing_bot_padding);
+    // layer padding (data-printingTopPadding / data-printingBotPadding) overrides global
+    int layer_top_padding = current_layer_->printingTopPadding();
+    int layer_bot_padding = current_layer_->printingBotPadding();
+    factory_->set_slice_top_padding(layer_top_padding >= 0 ? layer_top_padding : config_.printing_top_padding);
+    factory_->set_slice_bot_padding(layer_bot_padding >= 0 ? layer_bot_padding : config_.printing_bot_padding);
   } else if (is_uv_layer_) {
     kwargs.interpolation = current_layer_->interpolation();
     factory_ = std::make_unique<UVBitmapFactory>(kwargs);


### PR DESCRIPTION
## Summary

- Parse `data-printingTopPadding` / `data-printingBotPadding` from layer `<g>` elements (same attribute table as `data-rightPadding` in `createGNode`), carried through `BeamLayerConfig` → `Layer`.
- In `convertPrintingLayer`, a layer's value (>= 0) overrides the global `ptp` / `pbp` task params when setting the factory's slice paddings; `-1` means unset and preserves today's global fallback behavior exactly.
- Units are px slice rows, matching the existing global params. fluxclient gets the equivalent change so both engines behave the same.

## Motivation

beam-studio printing test files (e.g. `beamo_2_printing_test.beam` for beamo II) must run with zero top/bottom printing padding, without affecting other files. The padding override travels inside the file as layer attributes, so it applies regardless of how the file is opened. beam-studio also flattens these into the global `ptp` / `pbp` as a fallback for older backends, and its `getDefaultConfig()` has no `printingTopPadding` / `printingBotPadding` keys, so the `getAttr` default-config lookup falls back to `-1` (unset) when the attribute is absent.

## Test notes

- Not compiled locally (no Qt env on this machine) — please rely on CI.
- To verify behavior: convert a beamo II 4C printing task from `beamo_2_printing_test.beam` (layers carry `data-printingTopPadding="0"` / `data-printingBotPadding="0"`) and confirm the slices have no top/bottom padding, while a normal printing task still gets the global 10 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)