### PR TITLE
Update s-curve parameters and one-way engraving for high quality

### DIFF
--- a/src/toolpath_exporter/factories/laser.cpp
+++ b/src/toolpath_exporter/factories/laser.cpp
@@ -155,7 +155,11 @@ bool LaserBitmapFactory::fg_iterate_x_pwm(const uchar* data,
     left_x += backlash;
     right_x += backlash;
   }
-  proc->moveto(NamedArgs().rx(reverse ? right_x : left_x).ry(y).set_is_travel());
+  // y-step at normal travel speed, then x return at working speed if it is
+  // faster than travel speed
+  float return_vel = qMax(speed, proc->get_travel_speed());
+  proc->moveto(NamedArgs().ry(y).set_is_travel());
+  proc->moveto(NamedArgs().rx(reverse ? right_x : left_x).rf(return_vel).set_is_travel());
   proc->moveto(NamedArgs().rx(reverse ? right_x : left_x).ry(y));  // for 3d curve, move z to start position
   proc->set_line_pixels(pixel_number);
 
@@ -221,7 +225,11 @@ bool LaserBitmapFactory::fg_iterate_x(const uchar* data,
     left_x += backlash;
     right_x += backlash;
   }
-  proc->moveto(NamedArgs().rx(reverse ? right_x : left_x).ry(y).set_is_travel());
+  // y-step at normal travel speed, then x return at working speed if it is
+  // faster than travel speed
+  float return_vel = qMax(speed, proc->get_travel_speed());
+  proc->moveto(NamedArgs().ry(y).set_is_travel());
+  proc->moveto(NamedArgs().rx(reverse ? right_x : left_x).rf(return_vel).set_is_travel());
   proc->moveto(NamedArgs().rx(reverse ? right_x : left_x).ry(y));  // for 3d curve, move z to start position
   proc->set_line_pixels(pixel_number);
 

--- a/src/toolpath_exporter/toolpath-exporter-fcode.cpp
+++ b/src/toolpath_exporter/toolpath-exporter-fcode.cpp
@@ -734,8 +734,12 @@ void ToolpathExporterFcode::preprocessLaserLayer() {
   };
   kwargs.split_bbox = config_.enable_segmentation;
   kwargs.one_way = current_layer_->isOneWayEngraving() ||
+                   layer_is_high_quality_ ||
                    (config_.enable_diode && current_layer_->isUseDiode() &&
                     config_.is_diode_one_way_engraving);
+  if (layer_is_high_quality_ && !current_layer_->isOneWayEngraving()) {
+    qInfo() << "High quality: force one-way engraving";
+  }
   kwargs.fg_pwm_limit = hw_profile.fg_pwm_limit;
 
   // Note: convert path without dpmm_x
@@ -856,8 +860,7 @@ void ToolpathExporterFcode::outputBitmapFcode() {
                                         current_layer_->sCurveAMax(),
                                         current_layer_->sCurveJerk()};
     } else {
-      s_curve_params = get_s_curve_parameters(hardware_, layer_speed_ / 60.0,
-                                              layer_is_high_quality_);
+      s_curve_params = get_s_curve_parameters(hardware_, layer_speed_ / 60.0);
     }
     if (s_curve_params) {
       s_curve_padding = calculate_s_curve_padding_dist(

--- a/src/toolpath_exporter/toolpath-utils.cpp
+++ b/src/toolpath_exporter/toolpath-utils.cpp
@@ -818,15 +818,20 @@ double get_padding_dist(double min_padding, float speed, float acc) {
 // std::nullopt if the hardware does not support s-curve.
 // Mirrors fluxclient/hw_profile/s_curve.py::get_s_curve_parameters.
 std::optional<SCurveParameters> get_s_curve_parameters(HardwareType hw_type,
-                                                       float speed,
-                                                       bool is_high_quality) {
+                                                       float speed) {
   if (hw_type == HardwareType::RF) {
-    if (speed < 1525) {
-      return SCurveParameters{0, is_high_quality ? 21000.0 : 30000.0, 800000};
-    } else if (speed < 1800) {
-      return SCurveParameters{0, is_high_quality ? 10500.0 : 15000.0, 800000};
+    if (speed <= 1500) {
+      return SCurveParameters{0, 30000, 800000};
+    } else if (speed <= 1600) {
+      return SCurveParameters{0, 23000, 800000};
+    } else if (speed <= 1700) {
+      return SCurveParameters{0, 22000, 800000};
+    } else if (speed <= 1800) {
+      return SCurveParameters{0, 21000, 800000};
+    } else if (speed <= 1900) {
+      return SCurveParameters{0, 15000, 400000};
     }
-    return SCurveParameters{0, is_high_quality ? 10500.0 : 15000.0, 400000};
+    return SCurveParameters{0, 14000, 400000};
   } else if (hw_type == HardwareType::BB2) {
     return SCurveParameters{8000, 20000, 300000};
   }

--- a/src/toolpath_exporter/toolpath-utils.h
+++ b/src/toolpath_exporter/toolpath-utils.h
@@ -110,8 +110,7 @@ struct SCurveParameters {
 };
 
 std::optional<SCurveParameters> get_s_curve_parameters(HardwareType hw_type,
-                                                       float speed,
-                                                       bool is_high_quality = false);
+                                                       float speed);
 
 /**
  * Compute the S-curve acceleration padding distance from explicit motion


### PR DESCRIPTION
## Summary
https://app.clickup.com/t/5719332/86eyhbzy2

Mirrors flux3dp/fluxclient-dev#66:
- Update RF s-curve parameters to a finer speed-tiered table (30000/23000/22000/21000 a_max at 800k jerk up to 1800 mm/s, then 15000/14000 at 400k jerk) and drop the `is_high_quality` variant from `get_s_curve_parameters()`
- High-quality layers on RF now force one-way engraving
- Fast-gradient row-start move is split: y-step at normal travel speed, then x return at `max(speed, travel_speed)` — speeds up the one-way travel-back at high working speeds while keeping the Y gantry at normal travel speed （目前只有純 X 方向移動時會套用 S curve，先動 y 再動 x 讓單向雕刻 travel 時也會套用到高速 S curve）

## Test plan
- [x] Build passes
- [x] Real-machine sanity run on RF (unlit return traverse at working speed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)